### PR TITLE
Add client entry gate for index page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,19 @@
 // INDEX app/page.tsx
 
-import Link from 'next/link'
 import Image from 'next/image'
 import neonZ from '@images/neonZ.png'
 import useScrollReveal from '@/hooks/useScrollReveal'
 import ParallaxLayer from '@/components/ParallaxLayer'
 import bgForegroundTop from '@images/alley-foreground-bg-skyline.png'
 import HookInjector from '@/components/HookInjector'
-import useAuthUser from '@/hooks/useAuthUser'
-import { useAccount } from 'wagmi'
 import s from '@/styles/Home.module.sass'
+import HomeEntryGate from '@/components/HomeEntryGate'
 
 // page metadata
 import { generateStaticMetadata } from '@/lib/metadataRouter'
-import SignInButton from '@/components/SignInButton'
-import SignInWithEthereum from '@/components/SignInWithEthereum'
 export const generateMetadata = generateStaticMetadata('/')
 
 export default function Home() {
-  const { userData } = useAuthUser()
-  const { isConnected } = useAccount()
   return (
     <>
       <HookInjector hook={useScrollReveal} />
@@ -61,17 +55,7 @@ export default function Home() {
         <p className='reveal'>We manufacture presence.</p>
         <p className='text-[#59fd53] text-[120%] rotate-[-2deg] reveal'>And we don&apos;t stop.</p>
 
-        {!userData ? (
-          isConnected ? (
-            <SignInButton />
-          ) : (
-            <SignInWithEthereum />
-          )
-        ) : (
-          <Link href='/sunnyside' className='button'>
-            Explore
-          </Link>
-        )}
+        <HomeEntryGate />
       </div>
       {/* end */}
 

--- a/src/components/HomeEntryGate.tsx
+++ b/src/components/HomeEntryGate.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import Link from 'next/link'
+import useAuthUser from '@/hooks/useAuthUser'
+import { useAccount } from 'wagmi'
+import SignInButton from '@/components/SignInButton'
+import SignInWithEthereum from '@/components/SignInWithEthereum'
+
+export default function HomeEntryGate() {
+  const { userData } = useAuthUser()
+  const { isConnected } = useAccount()
+
+  if (!userData) {
+    return isConnected ? <SignInButton /> : <SignInWithEthereum />
+  }
+
+  return (
+    <Link href='/sunnyside' className='button'>
+      Explore
+    </Link>
+  )
+}


### PR DESCRIPTION
## Summary
- create `HomeEntryGate` to handle conditional sign in logic
- update `app/page.tsx` to use the new gate so the page can remain a server component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e50c88a883209594801be39b63ba