### PR TITLE
Add wallet, auth and NFT trait gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,51 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Access Gates
+
+The project includes optional wrapper components for gating access based on wallet state, Firebase authentication and NFT ownership.
+
+### `WalletGate`
+Wraps its children only when a wallet is connected.
+
+```tsx
+<WalletGate fallback={<ConnectWallet />}>
+  {...content}
+</WalletGate>
+```
+
+### `FirebaseGate`
+Ensures the user is signed in with Firebase before rendering children.
+
+```tsx
+<FirebaseGate fallback={<SignInWithEthereum />}>
+  {...content}
+</FirebaseGate>
+```
+
+### `NftTraitGate`
+Checks that the connected wallet owns an NFT from the configured contract with a specific trait.
+
+```tsx
+<NftTraitGate traitType="Role" traitValue="Founder" fallback={<p>No access</p>}>
+  {...content}
+</NftTraitGate>
+```
+
+### Nesting Gates
+Gates can be combined to protect sections of the UI:
+
+```tsx
+<WalletGate fallback={<ConnectWallet />}> 
+  <FirebaseGate fallback={<SignInWithEthereum />}> 
+    <NftTraitGate traitType="Role" traitValue="Founder" fallback={<p>No access</p>}>
+      {children}
+    </NftTraitGate>
+  </FirebaseGate>
+</WalletGate>
+```
+
+The NFT contract address used by `NftTraitGate` is defined in `src/lib/contracts.ts` as `MAIN_NFT_CONTRACT`.
+Update it in one place if the address changes.
+

--- a/src/components/gates/FirebaseGate.tsx
+++ b/src/components/gates/FirebaseGate.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+// components/gates/FirebaseGate.tsx
+import { ReactNode } from 'react'
+import useAuthUser from '@/hooks/useAuthUser'
+
+interface FirebaseGateProps {
+  fallback?: ReactNode
+  children: ReactNode
+}
+
+export default function FirebaseGate({ children, fallback = null }: FirebaseGateProps) {
+  const { user, loading } = useAuthUser()
+
+  if (loading) return null
+  if (!user) return <>{fallback}</>
+
+  return <>{children}</>
+}

--- a/src/components/gates/NftTraitGate.tsx
+++ b/src/components/gates/NftTraitGate.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+// components/gates/NftTraitGate.tsx
+import { ReactNode } from 'react'
+import useHasNftTrait from '@/hooks/useHasNftTrait'
+
+interface NftTraitGateProps {
+  traitType: string
+  traitValue: string
+  fallback?: ReactNode
+  children: ReactNode
+}
+
+export default function NftTraitGate({ traitType, traitValue, children, fallback = null }: NftTraitGateProps) {
+  const { hasTrait, loading } = useHasNftTrait(traitType, traitValue)
+
+  if (loading) return null
+  if (!hasTrait) return <>{fallback}</>
+
+  return <>{children}</>
+}

--- a/src/components/gates/WalletGate.tsx
+++ b/src/components/gates/WalletGate.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+// components/gates/WalletGate.tsx
+import { ReactNode } from 'react'
+import { useAccount } from 'wagmi'
+
+interface WalletGateProps {
+  fallback?: ReactNode
+  children: ReactNode
+}
+
+export default function WalletGate({ children, fallback = null }: WalletGateProps) {
+  const { isConnected } = useAccount()
+  if (!isConnected) return <>{fallback}</>
+  return <>{children}</>
+}

--- a/src/hooks/useHasNftTrait.ts
+++ b/src/hooks/useHasNftTrait.ts
@@ -1,0 +1,49 @@
+'use client'
+
+// hooks/useHasNftTrait.ts
+import { useEffect, useState } from 'react'
+import { useAccount } from 'wagmi'
+import { MAIN_NFT_CONTRACT } from '@/lib/contracts'
+
+interface UseHasNftTraitResult {
+  hasTrait: boolean
+  loading: boolean
+}
+
+export default function useHasNftTrait(traitType: string, traitValue: string): UseHasNftTraitResult {
+  const { address } = useAccount()
+  const [hasTrait, setHasTrait] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const checkTrait = async () => {
+      if (!address) {
+        setHasTrait(false)
+        setLoading(false)
+        return
+      }
+
+      try {
+        const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY
+        const url = `https://base-sepolia.g.alchemy.com/nft/v3/${apiKey}/getNFTsForOwner?owner=${address}&contractAddresses[]=${MAIN_NFT_CONTRACT}&withMetadata=true`
+        const res = await fetch(url)
+        const data = await res.json()
+        const owned = data.ownedNfts || []
+        const match = owned.some((nft: any) =>
+          nft.rawMetadata?.attributes?.some(
+            (attr: any) => attr.trait_type === traitType && attr.value === traitValue
+          )
+        )
+        setHasTrait(match)
+      } catch (err) {
+        console.error('Trait check failed', err)
+        setHasTrait(false)
+      }
+      setLoading(false)
+    }
+
+    checkTrait()
+  }, [address, traitType, traitValue])
+
+  return { hasTrait, loading }
+}

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -1,0 +1,5 @@
+// lib/contracts.ts
+
+// central registry for deployed contract addresses used across the app
+
+export const MAIN_NFT_CONTRACT = '0x2e51a8FdC067e415CFD5d00b9add5C6Af72d676c'


### PR DESCRIPTION
## Summary
- centralize contract addresses in `src/lib/contracts.ts`
- add wallet connection `WalletGate`
- add firebase auth `FirebaseGate`
- add NFT trait gating with `NftTraitGate` and supporting hook
- document gate usage in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685469beffbc8320a543e72594fe5abc