### PR TITLE
Add NFT count gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ Checks that the connected wallet owns an NFT from the configured contract with a
 </NftTraitGate>
 ```
 
+### `NftCountGate`
+Checks that the connected wallet holds at least a minimum number of NFTs from the configured contract.
+
+```tsx
+<NftCountGate minimum={2} fallback={<p>No access</p>}>
+  {...content}
+</NftCountGate>
+```
+
 ### Nesting Gates
 Gates can be combined to protect sections of the UI:
 
@@ -79,7 +88,7 @@ Gates can be combined to protect sections of the UI:
 </WalletGate>
 ```
 
-The NFT contract address used by `NftTraitGate` is defined in `src/lib/contracts.ts` as `MAIN_NFT_CONTRACT`.
+The NFT contract address used by `NftTraitGate` and `NftCountGate` is defined in `src/lib/contracts.ts` as `MAIN_NFT_CONTRACT`.
 Update it in one place if the address changes.
 
 ### `AuthGate`

--- a/src/components/gates/NftCountGate.tsx
+++ b/src/components/gates/NftCountGate.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+// components/gates/NftCountGate.tsx
+import { ReactNode } from 'react'
+import useNftCount from '@/hooks/useNftCount'
+
+interface NftCountGateProps {
+  minimum: number
+  fallback?: ReactNode
+  children: ReactNode
+}
+
+export default function NftCountGate({ minimum, children, fallback = null }: NftCountGateProps) {
+  const { count, loading } = useNftCount()
+
+  if (loading) return null
+  if (count < minimum) return <>{fallback}</>
+
+  return <>{children}</>
+}

--- a/src/hooks/useNftCount.ts
+++ b/src/hooks/useNftCount.ts
@@ -1,0 +1,45 @@
+'use client'
+
+// hooks/useNftCount.ts
+import { useEffect, useState } from 'react'
+import { useAccount } from 'wagmi'
+import { MAIN_NFT_CONTRACT } from '@/lib/contracts'
+import type { AlchemyNftsResponse } from '@/types/Nft'
+
+interface UseNftCountResult {
+  count: number
+  loading: boolean
+}
+
+export default function useNftCount(): UseNftCountResult {
+  const { address } = useAccount()
+  const [count, setCount] = useState(0)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchCount = async () => {
+      if (!address) {
+        setCount(0)
+        setLoading(false)
+        return
+      }
+
+      try {
+        const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY
+        const url = `https://base-sepolia.g.alchemy.com/nft/v3/${apiKey}/getNFTsForOwner?owner=${address}&contractAddresses[]=${MAIN_NFT_CONTRACT}&withMetadata=false`
+        const res = await fetch(url)
+        const data = (await res.json()) as AlchemyNftsResponse
+        const owned = data.ownedNfts ?? []
+        setCount(owned.length)
+      } catch (err) {
+        console.error('NFT count check failed', err)
+        setCount(0)
+      }
+      setLoading(false)
+    }
+
+    fetchCount()
+  }, [address])
+
+  return { count, loading }
+}


### PR DESCRIPTION
## Summary
- create `useNftCount` hook that queries Alchemy for wallet NFT count
- add `NftCountGate` component
- document new gate in README

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854eab5030883208c2c30a83a16c0e4