### PR TITLE
Handle Firestore snapshot errors

### DIFF
--- a/src/hooks/useFirestoreCollection.ts
+++ b/src/hooks/useFirestoreCollection.ts
@@ -31,12 +31,18 @@ export function useFirestoreCollection<D extends DocumentData>(collectionName: s
   useEffect(() => {
     const colRef = collection(db, collectionName) as CollectionReference<D>
 
-    const unsub = onSnapshot(colRef, (snap) => {
-      const docs = snap.docs.map((d) => ({
-        id: d.id,
-        ...(d.data() as D),
-      }))
-      setItems(docs)
+    const unsub = onSnapshot(colRef, {
+      next: (snap) => {
+        const docs = snap.docs.map((d) => ({
+          id: d.id,
+          ...(d.data() as D),
+        }))
+        setItems(docs)
+      },
+      error: (err) => {
+        console.error('[FirestoreCollection] Snapshot error:', err)
+        setItems([])
+      },
     })
 
     return () => unsub()

--- a/src/layout/Providers/AuthProvider.tsx
+++ b/src/layout/Providers/AuthProvider.tsx
@@ -43,13 +43,20 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
 
       if (firebaseUser) {
         const ref = doc(db, 'users', firebaseUser.uid)
-        unsubscribeSnapshot = onSnapshot(ref, (snap) => {
-          if (snap.exists()) {
-            setUserData(snap.data() as UserData)
-          } else {
+        unsubscribeSnapshot = onSnapshot(ref, {
+          next: (snap) => {
+            if (snap.exists()) {
+              setUserData(snap.data() as UserData)
+            } else {
+              setUserData(null)
+            }
+            setLoading(false)
+          },
+          error: (err) => {
+            console.error('[AuthProvider] Snapshot error:', err)
             setUserData(null)
-          }
-          setLoading(false)
+            setLoading(false)
+          },
         })
       } else {
         setUserData(null)


### PR DESCRIPTION
## Summary
- add error callbacks to Firestore snapshot listeners

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854f2e037b0832095ca79f6855ea4dc