### PR TITLE
Improve auth handling with wallet integration

### DIFF
--- a/src/components/SignInWithEthereum.tsx
+++ b/src/components/SignInWithEthereum.tsx
@@ -22,24 +22,7 @@ export default function SignInWithEthereum() {
   const { signMessageAsync } = useSignMessage()
   const { chains: cfgChains } = useConfig()
 
-  // -- start: disconnect fn (clear firebase + cookie) --
-  const handleDisconnect = async () => {
-    const uid = auth.currentUser?.uid
-
-    await fetch('/api/siwe/session', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: '' }),
-    })
-
-    await signOut(auth)
-
-    if (uid) {
-      localStorage.removeItem(`dailyXP:${uid}`)
-    }
-    console.log('Signed out and cleared session cookie')
-  }
-  // -- end: disconnect fn --
+  // auth disconnect handled globally
 
   // -- start: handle sign in fn --
   const handleSignIn = useCallback(async () => {
@@ -121,22 +104,7 @@ export default function SignInWithEthereum() {
   }, [address, chain, cfgChains, signMessageAsync])
   // -- end: handle sign in fn --
 
-  // -- start: auto-trigger auth sync on wallet state --
-  useEffect(() => {
-    const delaySignIn = async () => {
-      await new Promise((resolve) => setTimeout(resolve, 500)) // slight delay to allow wallet to stabilize
-      if (!auth.currentUser && address) {
-        handleSignIn()
-      }
-    }
-
-    if (!isConnected) {
-      handleDisconnect()
-    } else {
-      delaySignIn()
-    }
-  }, [isConnected, address, handleSignIn])
-  // -- end: effect --
+  // auth state is now managed by AuthProvider
 
   // -- start: render wallet ui --
   return (

--- a/src/layout/Providers/AuthProvider.tsx
+++ b/src/layout/Providers/AuthProvider.tsx
@@ -2,21 +2,39 @@
 
 // app/layout/Providers/AuthProvider.tsx
 import { createContext, useContext, useEffect, useState } from 'react'
-import { getAuth, onAuthStateChanged, type User } from 'firebase/auth'
-import { doc, onSnapshot } from 'firebase/firestore'
+import {
+  browserLocalPersistence,
+  setPersistence,
+  signInWithCustomToken,
+  signOut,
+  getAuth,
+  onAuthStateChanged,
+  type User,
+} from 'firebase/auth'
+import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore'
+import { useAccount, useSignMessage, useConfig } from 'wagmi'
+import { createSiweMessage } from 'viem/siwe'
 import { db } from '@/lib/firebaseClient'
+import { MAIN_NFT_CONTRACT } from '@/lib/contracts'
 import { useDailyLoginReward } from '@/hooks/useDailyLoginReward'
+import type { AlchemyNftsResponse } from '@/types/Nft'
 import type { UserData } from '@/types/UserData'
 
 interface AuthContextValue {
   user: User | null
   userData: UserData | null
+  address?: string
+  isConnected: boolean
+  hasNft: boolean
   loading: boolean
 }
 
 const AuthContext = createContext<AuthContextValue>({
   user: null,
   userData: null,
+  address: undefined,
+  isConnected: false,
+  hasNft: false,
   loading: true,
 })
 
@@ -25,9 +43,71 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   const [user, setUser] = useState<User | null>(null)
   const [userData, setUserData] = useState<UserData | null>(null)
   const [loading, setLoading] = useState(true)
+  const { address, chain, isConnected } = useAccount()
+  const { signMessageAsync } = useSignMessage()
+  const { chains: cfgChains } = useConfig()
+  const [hasNft, setHasNft] = useState(false)
 
   // trigger daily xp reward once per login
   useDailyLoginReward(user)
+
+  const handleDisconnect = async () => {
+    await fetch('/api/siwe/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: '' }),
+    })
+    await signOut(getAuth())
+  }
+
+  const handleSignIn = async () => {
+    if (!address) return
+    try {
+      const chainId = chain?.id ?? cfgChains[0].id
+      const { nonce } = await fetch('/api/siwe/nonce').then((r) => r.json())
+      const message = createSiweMessage({
+        domain: window.location.host,
+        address,
+        statement: 'Sign in with Ethereum to app',
+        uri: window.location.origin,
+        version: '1',
+        chainId,
+        nonce,
+      })
+      const signature = await signMessageAsync({ message })
+      const res = await fetch('/api/siwe/verify', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message, signature }),
+      })
+      if (!res.ok) throw new Error('SIWE verify failed')
+      const { token } = await res.json()
+      const auth = getAuth()
+      await setPersistence(auth, browserLocalPersistence)
+      await signInWithCustomToken(auth, token)
+      const idToken = await auth.currentUser?.getIdToken()
+      await fetch('/api/siwe/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: idToken }),
+      })
+      const uid = auth.currentUser?.uid
+      if (uid) {
+        const userDocRef = doc(db, 'users', uid)
+        const userSnapshot = await getDoc(userDocRef)
+        if (!userSnapshot.exists()) {
+          await setDoc(userDocRef, {
+            address,
+            experience: 0,
+            level: 1,
+            createdAt: Date.now(),
+          })
+        }
+      }
+    } catch (err) {
+      console.error('[AuthProvider] Sign-in error:', err)
+    }
+  }
 
   useEffect(() => {
     const auth = getAuth()
@@ -70,7 +150,41 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
     }
   }, [])
 
-  return <AuthContext.Provider value={{ user, userData, loading }}>{children}</AuthContext.Provider>
+  useEffect(() => {
+    const syncWallet = async () => {
+      if (!isConnected) {
+        await handleDisconnect()
+        setHasNft(false)
+        return
+      }
+
+      if (!getAuth().currentUser) {
+        await handleSignIn()
+      }
+
+      try {
+        const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY
+        const res = await fetch(
+          `https://base-sepolia.g.alchemy.com/nft/v3/${apiKey}/getNFTsForOwner?owner=${address}&contractAddresses[]=${MAIN_NFT_CONTRACT}&withMetadata=false`
+        )
+        const data = (await res.json()) as AlchemyNftsResponse
+        setHasNft((data.ownedNfts ?? []).length > 0)
+      } catch (err) {
+        console.error('[AuthProvider] NFT check failed', err)
+        setHasNft(false)
+      }
+    }
+
+    syncWallet()
+  }, [address, isConnected])
+
+  return (
+    <AuthContext.Provider
+      value={{ user, userData, address, isConnected, hasNft, loading }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
 }
 // -- end: AuthProvider --
 


### PR DESCRIPTION
## Summary
- manage wallet sign-in and NFT checks inside `AuthProvider`
- trim unused logic from `SignInWithEthereum`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'remark-autolink-headings')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f90c50208320945b29aedaad46b0