### PR TITLE
Fix provider order for wagmi context

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,18 +40,17 @@ export default function RootLayout({
       <body className={`${dmSans.variable} ${dmMono.variable} antialiased`} id='top'>
         <Loader />
         <BodyClassManager />
-        {/* -- firebase sdk -- */}
-        <AuthProvider>
-          {/* -- onchainkit sdk + siwe | https://docs.base.org/builderkits/onchainkit -- */}
-          <Web3Providers>
+        {/* -- web3 sdk + firebase -- */}
+        <Web3Providers>
+          <AuthProvider>
             {/* -- runtime mgr -- */}
             <ClientAppShell>
               <Header />
               <main>{children}</main>
               <Footer />
             </ClientAppShell>
-          </Web3Providers>
-        </AuthProvider>
+          </AuthProvider>
+        </Web3Providers>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- wrap `AuthProvider` in `Web3Providers` so wagmi context is available

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fee947848320a0e4aa0e64d3c6f2