### PR TITLE
Improve Firebase setup error messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,5 @@ service cloud.firestore {
 ```
 
 Errors such as `Unexpected token 'M', "Must be au" is not valid JSON` usually mean an API route returned an HTML error page. Verify that all environment variables listed above are set correctly so the backend can authenticate with Firebase.
+
+If you encounter `Service account object must contain a string "project_id" property`, the Firebase Admin credentials are incomplete. Ensure `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL` and `FIREBASE_PRIVATE_KEY` are defined in `.env.local`.

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -3,12 +3,19 @@ import { initializeApp, cert, getApps } from 'firebase-admin/app'
 import { getAuth } from 'firebase-admin/auth'
 import { getFirestore } from 'firebase-admin/firestore'
 
+function assertEnv(name: string, value: string | undefined): string {
+  if (!value) {
+    throw new Error(`Missing required Firebase env var: ${name}`)
+  }
+  return value
+}
+
 if (!getApps().length) {
   initializeApp({
     credential: cert({
-      projectId: process.env.FIREBASE_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      projectId: assertEnv('FIREBASE_PROJECT_ID', process.env.FIREBASE_PROJECT_ID),
+      clientEmail: assertEnv('FIREBASE_CLIENT_EMAIL', process.env.FIREBASE_CLIENT_EMAIL),
+      privateKey: assertEnv('FIREBASE_PRIVATE_KEY', process.env.FIREBASE_PRIVATE_KEY)?.replace(/\\n/g, '\n'),
     }),
   })
 }


### PR DESCRIPTION
## Summary
- clarify troubleshooting steps when Firebase Admin env vars are missing
- check for required Firebase env vars in firebaseAdmin initialization

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551e17d1988320b9313f5fd09f507e