### PR TITLE
Handle base64 encoded firebase keys

### DIFF
--- a/src/app/api/siwe/verify/route.ts
+++ b/src/app/api/siwe/verify/route.ts
@@ -10,7 +10,11 @@ if (!admin.apps.length) {
     credential: admin.credential.cert({
       projectId: process.env.FIREBASE_PROJECT_ID!,
       clientEmail: process.env.FIREBASE_CLIENT_EMAIL!,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY!.replace(/\\n/g, '\n'),
+      privateKey: (() => {
+        const key = process.env.FIREBASE_PRIVATE_KEY!
+        const normalized = key.replace(/\\n/g, '\n')
+        return normalized.includes('BEGIN') ? normalized : Buffer.from(normalized, 'base64').toString('utf8')
+      })(),
     }),
   })
 }

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -15,7 +15,11 @@ if (!getApps().length) {
     credential: cert({
       projectId: assertEnv('FIREBASE_PROJECT_ID', process.env.FIREBASE_PROJECT_ID),
       clientEmail: assertEnv('FIREBASE_CLIENT_EMAIL', process.env.FIREBASE_CLIENT_EMAIL),
-      privateKey: assertEnv('FIREBASE_PRIVATE_KEY', process.env.FIREBASE_PRIVATE_KEY)?.replace(/\\n/g, '\n'),
+      privateKey: (() => {
+        const key = assertEnv('FIREBASE_PRIVATE_KEY', process.env.FIREBASE_PRIVATE_KEY)
+        const normalized = key.replace(/\\n/g, '\n')
+        return normalized.includes('BEGIN') ? normalized : Buffer.from(normalized, 'base64').toString('utf8')
+      })(),
     }),
   })
 }


### PR DESCRIPTION
## Summary
- support base64 encoded private keys when initializing Firebase Admin
- do the same for the SIWE API route

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685596bda418832085b56d4dbc202d66