### PR TITLE
Add menu registry and orientation options to flyout menu

### DIFF
--- a/src/components/FlyoutMenu.tsx
+++ b/src/components/FlyoutMenu.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import SpotDotsSvg from '@/components/svg/SpotDotsSvg'
 import { getRouteEntry } from '@/lib/routeRegistry'
+import { getMenuItems } from '@/lib/menuRegistry'
 
 const gridPositions = [
   [-1, 0],
@@ -21,7 +22,20 @@ const gridPositions = [
 
 const spacing = 80
 
-const FlyoutMenu = () => {
+type Corner = 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'
+
+interface FlyoutMenuProps {
+  corner?: Corner
+}
+
+const orientationModifiers: Record<Corner, [number, number]> = {
+  'top-right': [1, 1],
+  'top-left': [-1, 1],
+  'bottom-right': [1, -1],
+  'bottom-left': [-1, -1],
+}
+
+const FlyoutMenu = ({ corner = 'bottom-left' }: FlyoutMenuProps) => {
   const pathname = usePathname()
   const [open, setOpen] = useState(false)
 
@@ -38,13 +52,13 @@ const FlyoutMenu = () => {
   }, [])
 
   const routeEntry = getRouteEntry(pathname)
-  const menuItems = routeEntry?.menuItems || []
+  const menuItems = getMenuItems(routeEntry?.menuId)
 
   if (menuItems.length === 0) return null
 
   return (
     <div
-      className='toolbar'
+      className={`toolbar ${corner}`}
       style={{
         width: open ? '400px' : '100px',
         height: open ? '400px' : '100px',
@@ -57,6 +71,7 @@ const FlyoutMenu = () => {
 
         const distance = Math.sqrt(x * x + y * y)
         const brightness = Math.max(0.1, 1 + 0.075 * distance)
+        const [xMod, yMod] = orientationModifiers[corner]
 
         return (
           <Link
@@ -64,7 +79,9 @@ const FlyoutMenu = () => {
             href={item.link}
             className={`absolute top-[35px] right-[30px] w-[60px] h-[60px] ${item.className || ''}`}
             style={{
-              transform: open ? `translate(${x * spacing}px, ${y * spacing}px)` : 'translate(0px, 0px) scale(0)',
+              transform: open
+                ? `translate(${x * spacing * xMod}px, ${y * spacing * yMod}px)`
+                : 'translate(0px, 0px) scale(0)',
               opacity: open ? 1 : 0,
               filter: `brightness(${brightness})`,
               transition: 'transform 0.4s ease, opacity 0.3s ease, filter 0.3s ease, margin-top 0.3s ease',

--- a/src/lib/menuRegistry.ts
+++ b/src/lib/menuRegistry.ts
@@ -1,0 +1,20 @@
+import type { MenuItem } from '@/types/Route'
+
+export const MenuRegistry: Record<string, MenuItem[]> = {
+  default: [
+    { icon: 'arrow_left_128.png', title: 'Exit', link: '/', className: 'exit' },
+  ],
+  sunnyside: [
+    { icon: 'buynow_128.png', title: 'Stash', link: '/sunnyside/stash', className: '' },
+  ],
+  sunnysideExit: [
+    { icon: 'arrow_left_128.png', title: 'Exit', link: '/sunnyside', className: 'exit' },
+  ],
+}
+
+export function getMenuItems(menuId?: string): MenuItem[] {
+  if (menuId && MenuRegistry[menuId]) {
+    return MenuRegistry[menuId]
+  }
+  return MenuRegistry['default']
+}

--- a/src/lib/routeRegistry.ts
+++ b/src/lib/routeRegistry.ts
@@ -8,33 +8,33 @@ export const RouteRegistry: RouteEntry[] = [
     bodyClass: 'index',
     metaTitle: 'New Yolk City',
     audio: '/assets/audio/city-background-ambience-01.mp3',
-    menuItems: [{ icon: 'arrow_left_128.png', title: 'Exit', link: '/', className: 'exit' }],
+    menuId: 'default',
   },
   /* -- S E T T I N G S -- */
   {
     path: '/settings',
     bodyClass: 'settings',
     metaTitle: 'My Settings',
-    menuItems: [{ icon: 'arrow_left_128.png', title: 'Exit', link: '/', className: 'exit' }],
+    menuId: 'default',
   },
   {
     path: '/settings/role',
     bodyClass: 'settings',
     metaTitle: 'My Roles',
-    menuItems: [{ icon: 'arrow_left_128.png', title: 'Exit', link: '/', className: 'exit' }],
+    menuId: 'default',
   },
   {
     path: '/settings/usertag',
     bodyClass: 'settings',
     metaTitle: 'My Usertag',
-    menuItems: [{ icon: 'arrow_left_128.png', title: 'Exit', link: '/', className: 'exit' }],
+    menuId: 'default',
   },
   /* -- A C T I V I T Y -- */
   {
     path: '/activity',
     bodyClass: 'activity',
     metaTitle: 'Activity Feed',
-    menuItems: [{ icon: 'arrow_left_128.png', title: 'Exit', link: '/', className: 'exit' }],
+    menuId: 'default',
   },
   /* -- S U N N Y S I D E -- */
   {
@@ -44,12 +44,7 @@ export const RouteRegistry: RouteEntry[] = [
     locationId: 'sunnyside',
     xpReward: 15,
     audio: '/assets/audio/city-background-ambience-01.mp3',
-    menuItems: [
-      //{ icon: 'lab-mouse_128.png', title: '', link: '#bottom', className: '' },
-      //{ icon: 'list_128.png', title: 'Deep Dive', link: '/deep-dive', className: '' },
-      //{ icon: 'list_128.png', title: 'Season', link: '/sunnyside', className: '' },
-      { icon: 'buynow_128.png', title: 'Stash', link: '/sunnyside/stash', className: '' },
-    ],
+    menuId: 'sunnyside',
   },
   {
     path: '/sunnyside/stash',
@@ -57,7 +52,7 @@ export const RouteRegistry: RouteEntry[] = [
     metaTitle: 'Sunnyside Stash',
     locationId: 'sunnyside_stash',
     xpReward: 15,
-    menuItems: [{ icon: 'arrow_left_128.png', title: 'Exit', link: '/sunnyside', className: 'exit' }],
+    menuId: 'sunnysideExit',
   },
   {
     path: '/sunnyside/row',
@@ -65,14 +60,14 @@ export const RouteRegistry: RouteEntry[] = [
     metaTitle: 'Sunnyside Row',
     locationId: 'sunnyside_row',
     xpReward: 15,
-    menuItems: [{ icon: 'arrow_left_128.png', title: 'Exit', link: '/sunnyside', className: 'exit' }],
+    menuId: 'sunnysideExit',
   },
   /* -- D E E P   D I V E -- */
   {
     path: '/deep-dive',
     bodyClass: 'docs',
     metaTitle: 'Deep Dive',
-    menuItems: [{ icon: 'arrow_left_128.png', title: 'Exit', link: '/', className: 'exit' }],
+    menuId: 'default',
   },
   /* -- L O R E -- */
   {

--- a/src/styles/globals.sass
+++ b/src/styles/globals.sass
@@ -596,8 +596,19 @@ footer.upside
   .iconImage
     @apply inline-block bg-[#555] rounded-full relative top-[0] mr-[3px]
   .toolbar
-    @apply fixed top-[0] right-[0] pt-[44px] pr-[40px]
-    background: radial-gradient(circle at top right, #000, rgba(0,0,0,0) 50%)
+    @apply fixed
+    &.bottom-left
+      @apply bottom-[0] left-[0] pb-[44px] pl-[40px]
+      background: radial-gradient(circle at bottom left, #000, rgba(0,0,0,0) 50%)
+    &.bottom-right
+      @apply bottom-[0] right-[0] pb-[44px] pr-[40px]
+      background: radial-gradient(circle at bottom right, #000, rgba(0,0,0,0) 50%)
+    &.top-left
+      @apply top-[0] left-[0] pt-[44px] pl-[40px]
+      background: radial-gradient(circle at top left, #000, rgba(0,0,0,0) 50%)
+    &.top-right
+      @apply top-[0] right-[0] pt-[44px] pr-[40px]
+      background: radial-gradient(circle at top right, #000, rgba(0,0,0,0) 50%)
     button.hamburger
       @apply absolute top-[35px] right-[30px] w-[60px] h-[60px] z-20
       svg

--- a/src/types/Route.ts
+++ b/src/types/Route.ts
@@ -7,7 +7,7 @@ export interface RouteEntry {
   ogImage?: string
   xpReward?: number
   audio?: string
-  menuItems?: MenuItem[]
+  menuId?: string
 }
 
 export interface MenuItem {


### PR DESCRIPTION
## Summary
- add `menuRegistry` for pre-defined flyout menus
- use `menuId` on route entries instead of menuItems arrays
- allow `FlyoutMenu` direction via new `corner` prop and compute item positions accordingly
- style flyout menu for each corner direction

## Testing
- `npx eslint --version`
- `npm run lint` *(fails: `next` not found)*
- `npx next lint` *(fails: network access)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68562f194f108320bc5fa5c5363f3ed6