### PR TITLE
Add chain info dropdown and mint button

### DIFF
--- a/src/app/sunnyside/stash/page.tsx
+++ b/src/app/sunnyside/stash/page.tsx
@@ -3,12 +3,12 @@
 import { generateStaticMetadata } from '@/lib/metadataRouter'
 export const generateMetadata = generateStaticMetadata('/sunnyside/stash')
 
-import Link from 'next/link'
 import Image from 'next/image'
 import LazySection from '@/layout/Containers/LazySection'
 import Footer from '@/layout/Footers/LanderFooter'
 import s from '@/styles/Home.module.sass'
 import SignInWithEthereum from '@/components/SignInWithEthereum'
+import MintNowButton from '@/components/MintNowButton'
 //import MintCard from '@/components/MintCard'
 
 export default function Home() {
@@ -79,7 +79,7 @@ export default function Home() {
               </a>
             </>
           ) : (
-            <Link href='#'>
+            <MintNowButton>
               <div className={`${s.eggCount} ${s.countLarge} ${s.product}`}>
                 <span id='eggPrice'>.03 ETH</span>
               </div>
@@ -88,7 +88,7 @@ export default function Home() {
                 <br />
                 NOw
               </span>
-            </Link>
+            </MintNowButton>
           )}
         </div>
         <Image src='/assets/images/Produx/output_4.png' alt='MFR Egg' width={800} height={800} className={s.egg} />
@@ -146,11 +146,11 @@ export default function Home() {
           </div>
         </section>
         <div className={s.centered}>
-          <Link href='/deep-dive' className={`${s.biglink} ${s.bigLinkLeft} ${s.noarrow}`}>
+          <MintNowButton className={`${s.biglink} ${s.bigLinkLeft} ${s.noarrow}`}> 
             Buy
             <Image src='/assets/images/glow-in-the-dark-closed.png' alt='Learn More' width={200} height={203} />
             Now
-          </Link>
+          </MintNowButton>
         </div>
         <hr />
         <section className={s.cta}>
@@ -175,11 +175,11 @@ export default function Home() {
         <div className={s.centered}>
           <Image src='/assets/images/plated.jpg' alt='MFR Egg Cartons' width={1092} height={450} />
           <br />
-          <Link href='/deep-dive' className={`${s.biglink} ${s.bigLinkLeft} ${s.noarrow}`}>
+          <MintNowButton className={`${s.biglink} ${s.bigLinkLeft} ${s.noarrow}`}> 
             Buy
             <Image src='/assets/images/glow-in-the-dark-closed.png' alt='Learn More' width={200} height={203} />
             Now
-          </Link>
+          </MintNowButton>
         </div>
       </LazySection>
       <LazySection>

--- a/src/components/ChainInfo.tsx
+++ b/src/components/ChainInfo.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useAccount } from 'wagmi'
+
+export default function ChainInfo() {
+  const { chain } = useAccount()
+  if (!chain) return null
+  return <div className='chain-info'>{chain.name}</div>
+}

--- a/src/components/MintNowButton.tsx
+++ b/src/components/MintNowButton.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState } from 'react'
+import { parseEther } from 'viem'
+import { useWriteContract, useWaitForTransactionReceipt } from 'wagmi'
+import { MintButton } from '@coinbase/onchainkit/mint'
+import CraftedCollectionABI from '@/abi/CraftedCollection.json'
+import { MAIN_NFT_CONTRACT } from '@/lib/contracts'
+
+export default function MintNowButton({ className }: { className?: string }) {
+  const [hash, setHash] = useState<`0x${string}` | null>(null)
+  const { writeContractAsync } = useWriteContract()
+  const { isLoading, isSuccess, isError } = useWaitForTransactionReceipt({ hash })
+
+  const handleMint = async () => {
+    try {
+      const txHash = await writeContractAsync({
+        address: MAIN_NFT_CONTRACT,
+        abi: CraftedCollectionABI.abi,
+        functionName: 'publicMint',
+        args: [1],
+        value: parseEther('0.03'),
+      })
+      setHash(txHash)
+    } catch (err) {
+      console.error('Mint failed', err)
+    }
+  }
+
+  let label = 'Buy\nNow'
+  if (isLoading) label = 'Minting...'
+  if (isSuccess) label = 'Minted!'
+  if (isError) label = 'Error'
+
+  return (
+    <div className={className}>
+      <MintButton onClick={handleMint} disabled={isLoading}>
+        {label}
+      </MintButton>
+    </div>
+  )
+}

--- a/src/components/SignInWithEthereum.tsx
+++ b/src/components/SignInWithEthereum.tsx
@@ -7,6 +7,7 @@ import { doc, getDoc, setDoc } from 'firebase/firestore'
 import { signInWithCustomToken, setPersistence, browserLocalPersistence } from 'firebase/auth'
 import { Wallet, ConnectWallet, WalletDropdown, WalletDropdownDisconnect, WalletDropdownLink } from '@coinbase/onchainkit/wallet'
 import { Avatar, Name, Address, EthBalance, Identity } from '@coinbase/onchainkit/identity'
+import ChainInfo from './ChainInfo'
 import { createSiweMessage } from 'viem/siwe'
 import { useAccount, useSignMessage, useConfig } from 'wagmi'
 import UserProfileCard from '@/components/UserProfileCard'
@@ -127,6 +128,7 @@ export default function SignInWithEthereum() {
           <Address />
           <EthBalance />
         </Identity>
+        <ChainInfo />
         <UserProfileCard />
         <WalletDropdownLink className='dd-link dd-settings' href='/settings'>
           Account Settings


### PR DESCRIPTION
## Summary
- show connected chain in wallet dropdown
- add reusable `MintNowButton` component for contract minting
- connect stash buy links to use `MintNowButton`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856650869648320b6c9a1197ca8fa32