### PR TITLE
Improve sign in flow

### DIFF
--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { auth, db } from '@/lib/firebaseClient'
 import { doc, getDoc, setDoc } from 'firebase/firestore'
 import { browserLocalPersistence, setPersistence, signInWithCustomToken } from 'firebase/auth'
@@ -11,10 +11,12 @@ export default function SignInButton() {
   const { address, chain } = useAccount()
   const { signMessageAsync } = useSignMessage()
   const { chains: cfgChains } = useConfig()
+  const [loading, setLoading] = useState(false)
 
   const handleSignIn = useCallback(async () => {
     try {
       if (!address) return
+      setLoading(true)
 
       const chainId = chain?.id ?? cfgChains[0].id
       const { nonce } = await fetch('/api/siwe/nonce').then((r) => r.json())
@@ -64,14 +66,23 @@ export default function SignInButton() {
       }
     } catch (err) {
       console.error('Sign-in error:', err)
+    } finally {
+      setLoading(false)
     }
   }, [address, chain, cfgChains, signMessageAsync])
 
   if (!address) return null
 
   return (
-    <button className='button' onClick={handleSignIn} type='button'>
-      Sign In
-    </button>
+    <>
+      <button className='button' onClick={handleSignIn} disabled={loading} type='button'>
+        Sign In
+      </button>
+      {loading && (
+        <div className='statusOverlay'>
+          <div className='statusMessage'>Signing in…</div>
+        </div>
+      )}
+    </>
   )
 }

--- a/src/components/SignInWithEthereum.tsx
+++ b/src/components/SignInWithEthereum.tsx
@@ -10,6 +10,7 @@ import { Avatar, Name, Address, EthBalance, Identity } from '@coinbase/onchainki
 import ChainInfo from './ChainInfo'
 import { createSiweMessage } from 'viem/siwe'
 import { useAccount, useSignMessage, useConfig } from 'wagmi'
+import useAuthUser from '@/hooks/useAuthUser'
 import UserProfileCard from '@/components/UserProfileCard'
 import FamilyRank from './FamilyRank'
 
@@ -19,9 +20,10 @@ export default function SignInWithEthereum() {
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
 
   // wagmi wallet state + signing config
-  const { address, chain } = useAccount()
+  const { address, chain, isConnected } = useAccount()
   const { signMessageAsync } = useSignMessage()
   const { chains: cfgChains } = useConfig()
+  const { user, userData } = useAuthUser()
 
   // auth disconnect handled globally
 
@@ -125,7 +127,11 @@ export default function SignInWithEthereum() {
         <ChainInfo />
         <Identity className='px-4 pt-3 pb-2' hasCopyAddressOnClick>
           <Avatar />
-          <Name />
+          {userData?.username ? (
+            <span className='usertag'>{userData.username}</span>
+          ) : (
+            <Name />
+          )}
           <Address />
           <EthBalance />
         </Identity>
@@ -136,6 +142,11 @@ export default function SignInWithEthereum() {
         <WalletDropdownLink className='dd-link dd-activity' href='/activity'>
           Activity
         </WalletDropdownLink>
+        {isConnected && !user && (
+          <button className='dd-link dd-signin' onClick={handleSignIn} type='button'>
+            Sign In
+          </button>
+        )}
         <WalletDropdownDisconnect />
       </WalletDropdown>
     </Wallet>

--- a/src/styles/globals.sass
+++ b/src/styles/globals.sass
@@ -470,6 +470,11 @@ h2.ock-font-family
     @apply text-[14px] text-[#0a0a0a]
     line-height: 16px
 
+.usertag
+  @apply text-[16px] text-[#0a0a0a]
+  line-height: 18px
+  font-weight: bold
+
 .ock-connect
   @apply bg-transparent relative transition-all duration-300 w-[140px] h-[140px] min-w-[140px] p-0 text-[24px] bottom-[-7px] right-[-20px] z-[2]
   font-family: "SKT"

--- a/src/types/UserData.ts
+++ b/src/types/UserData.ts
@@ -8,5 +8,6 @@ export interface UserData {
   money?: number
   lastLogin?: number
   locations?: string[]
+  username?: string
   // add additional fields for user profile here
 }


### PR DESCRIPTION
## Summary
- show usertag instead of name in wallet dropdown
- expose Sign In button inside dropdown when wallet connected but not signed in
- add loading overlay to Sign In buttons
- extend `UserData` with optional username field

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e7ffe4788320917489b9797b95c8