### PR TITLE
Add global mint modal

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Footer from '@/layout/Footers/NavFooter'
 import Header from '@/layout/Headers/NavHeader'
 import AuthProvider from '@/layout/Providers/AuthProvider'
 import { Web3Providers } from '@/layout/Providers/Web3Providers'
+import { MintModalProvider } from '@/layout/Providers/MintModalProvider'
 import ClientAppShell from '@/systems/runtime/ClientAppShell'
 import BodyClassManager from '@/systems/runtime/BodyClassManager'
 
@@ -43,12 +44,14 @@ export default function RootLayout({
         {/* -- web3 sdk + firebase -- */}
         <Web3Providers>
           <AuthProvider>
-            {/* -- runtime mgr -- */}
-            <ClientAppShell>
-              <Header />
-              <main>{children}</main>
-              <Footer />
-            </ClientAppShell>
+            <MintModalProvider>
+              {/* -- runtime mgr -- */}
+              <ClientAppShell>
+                <Header />
+                <main>{children}</main>
+                <Footer />
+              </ClientAppShell>
+            </MintModalProvider>
           </AuthProvider>
         </Web3Providers>
       </body>

--- a/src/app/sunnyside/stash/page.tsx
+++ b/src/app/sunnyside/stash/page.tsx
@@ -8,7 +8,7 @@ import LazySection from '@/layout/Containers/LazySection'
 import Footer from '@/layout/Footers/LanderFooter'
 import s from '@/styles/Home.module.sass'
 import SignInWithEthereum from '@/components/SignInWithEthereum'
-import Link from 'next/link'
+import BuyNowButton from '@/components/BuyNowButton'
 //import MintCard from '@/components/MintCard'
 
 export default function Home() {
@@ -79,7 +79,7 @@ export default function Home() {
               </a>
             </>
           ) : (
-            <Link href='#'>
+            <BuyNowButton>
               <div className={`${s.eggCount} ${s.countLarge} ${s.product}`}>
                 <span id='eggPrice'>.03 ETH</span>
               </div>
@@ -88,7 +88,7 @@ export default function Home() {
                 <br />
                 NOw
               </span>
-            </Link>
+            </BuyNowButton>
           )}
         </div>
         <Image src='/assets/images/Produx/output_4.png' alt='MFR Egg' width={800} height={800} className={s.egg} />
@@ -146,11 +146,11 @@ export default function Home() {
           </div>
         </section>
         <div className={s.centered}>
-          <Link href='/deep-dive' className={`${s.biglink} ${s.bigLinkLeft} ${s.noarrow}`}>
+          <BuyNowButton className={`${s.biglink} ${s.bigLinkLeft} ${s.noarrow}`}>
             Buy
             <Image src='/assets/images/glow-in-the-dark-closed.png' alt='Learn More' width={200} height={203} />
             Now
-          </Link>
+          </BuyNowButton>
         </div>
         <hr />
         <section className={s.cta}>
@@ -175,11 +175,11 @@ export default function Home() {
         <div className={s.centered}>
           <Image src='/assets/images/plated.jpg' alt='MFR Egg Cartons' width={1092} height={450} />
           <br />
-          <Link href='/deep-dive' className={`${s.biglink} ${s.bigLinkLeft} ${s.noarrow}`}>
+          <BuyNowButton className={`${s.biglink} ${s.bigLinkLeft} ${s.noarrow}`}>
             Buy
             <Image src='/assets/images/glow-in-the-dark-closed.png' alt='Learn More' width={200} height={203} />
             Now
-          </Link>
+          </BuyNowButton>
         </div>
       </LazySection>
       <LazySection>

--- a/src/components/BuyNowButton.tsx
+++ b/src/components/BuyNowButton.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { useMintModal } from '@/layout/Providers/MintModalProvider'
+
+export default function BuyNowButton({ children, className }: { children: ReactNode; className?: string }) {
+  const { open } = useMintModal()
+  return (
+    <button type='button' className={className} onClick={open}>
+      {children}
+    </button>
+  )
+}

--- a/src/components/MintModal.tsx
+++ b/src/components/MintModal.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import MintCard from './MintCard'
+
+export default function MintModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/80'>
+      <div className='relative bg-[var(--color-dark)] p-6 rounded-lg'>
+        <button
+          onClick={onClose}
+          className='absolute top-2 right-2 text-white'
+          aria-label='Close'
+        >
+          ✕
+        </button>
+        <MintCard />
+      </div>
+    </div>
+  )
+}

--- a/src/layout/Providers/MintModalProvider.tsx
+++ b/src/layout/Providers/MintModalProvider.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { createContext, useContext, useState, ReactNode } from 'react'
+import MintModal from '@/components/MintModal'
+
+interface Context {
+  open: () => void
+  close: () => void
+}
+
+const MintModalContext = createContext<Context | null>(null)
+
+export function MintModalProvider({ children }: { children: ReactNode }) {
+  const [visible, setVisible] = useState(false)
+
+  const open = () => setVisible(true)
+  const close = () => setVisible(false)
+
+  return (
+    <MintModalContext.Provider value={{ open, close }}>
+      {children}
+      {visible && <MintModal onClose={close} />}
+    </MintModalContext.Provider>
+  )
+}
+
+export function useMintModal() {
+  const ctx = useContext(MintModalContext)
+  if (!ctx) throw new Error('useMintModal must be used within MintModalProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add MintModalProvider for global minting state
- add MintModal and BuyNowButton components
- use MintModalProvider in app layout
- wire up "Buy Now" buttons on stash page

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68577d21d74483208e459e9b9aca3daf