### PR TITLE
Fix type hints and link purchases

### DIFF
--- a/src/app/shell/[id]/page.tsx
+++ b/src/app/shell/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { MAIN_NFT_CONTRACT } from '@/lib/contracts'
 import { notFound } from 'next/navigation'
+import type { NftAttribute } from '@/types/Nft'
 
 export const revalidate = 60
 
@@ -9,12 +10,12 @@ export default async function ShellPage({ params }: { params: { id: string } }) 
   const res = await fetch(url, { next: { revalidate: 60 } })
   if (!res.ok) notFound()
   const data = await res.json()
-  const traits = data?.metadata?.attributes ?? []
+  const traits: NftAttribute[] = data?.metadata?.attributes ?? []
   return (
     <div style={{ maxWidth: 800, margin: '2rem auto' }}>
       <h1>Shell #{params.id}</h1>
       <ul>
-        {traits.map((t: any, i: number) => (
+        {traits.map((t, i) => (
           <li key={i}>{t.trait_type}: {t.value}</li>
         ))}
       </ul>

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -71,7 +71,9 @@ export default function ProfilePage() {
 
       try {
         const userSnap = await getDoc(doc(db, 'users', data.uid))
-        const address = userSnap.exists() ? (userSnap.data() as any).address : null
+        const address = userSnap.exists()
+          ? (userSnap.data() as { address?: string }).address
+          : null
         if (address) {
           const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY
           const url = `https://base-sepolia.g.alchemy.com/nft/v3/${apiKey}/getNFTsForOwner?owner=${address}&contractAddresses[]=${MAIN_NFT_CONTRACT}`
@@ -165,7 +167,7 @@ export default function ProfilePage() {
                   : true
               )
               .map((nft, idx) => {
-                const tokenId = parseInt((nft as any).tokenId, 16)
+                const tokenId = parseInt(nft.tokenId ?? '0', 16)
                 return (
                   <li key={idx}>
                     <a href={`/shell/${tokenId}`}>Shell #{tokenId}</a>

--- a/src/components/MintCard.tsx
+++ b/src/components/MintCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 // components/MintCard.tsx
-import { useState } from 'react'
+import { useState, type ChangeEvent } from 'react'
 import { useWriteContract } from 'wagmi'
 import { parseEther } from 'viem'
 import { JsonRpcProvider, Interface } from 'ethers'
@@ -15,9 +15,9 @@ import useNftCount from '@/hooks/useNftCount'
 
 export default function MintCard() {
   const proxyAddress = '0x2e51a8FdC067e415CFD5d00b9add5C6Af72d676c'
-  const [quantity, setQuantity] = useState(1)
-  const pricePerNFT = parseEther('0.01')
-  const totalPrice = pricePerNFT * BigInt(quantity)
+  const [quantity, setQuantity] = useState<number>(1)
+  const pricePerNFT: bigint = parseEther('0.01')
+  const totalPrice: bigint = pricePerNFT * BigInt(quantity)
 
   const { writeContractAsync, isPending, error } = useWriteContract()
   const { user, address } = useAuthUser()
@@ -25,12 +25,12 @@ export default function MintCard() {
   const { count } = useNftCount()
   const maxAllowed = Math.max(0, 3 - count)
 
-  const handleQuantityChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleQuantityChange = (e: ChangeEvent<HTMLInputElement>) => {
     const val = Number(e.target.value)
     setQuantity(val > maxAllowed ? maxAllowed : val)
   }
 
-  const handleMint = async () => {
+  const handleMint = async (): Promise<void> => {
     if (!user) return
     if (maxAllowed === 0) return
     try {

--- a/src/components/UserPurchases.tsx
+++ b/src/components/UserPurchases.tsx
@@ -23,10 +23,10 @@ const UserPurchases: FC<Props> = ({ uid }) => {
           {purchases.map((p) => (
             <li key={p.id} className='py-[2px] px-[10px] text-[var(--color-dark)]'>
               <p className='text-sm'>
-                <b>{p.quantity} shell{p.quantity > 1 ? 's' : ''}</b> — {p.amount} ETH
-              </p>
-              <p className='text-xs'>
-                <Link href={`https://basescan.org/tx/${p.txHash}`} target='_blank'>tx</Link>
+                <b>{p.quantity} shell{p.quantity > 1 ? 's' : ''}</b> —{' '}
+                <Link href={`https://basescan.org/tx/${p.txHash}`} target='_blank'>
+                  {p.amount} ETH
+                </Link>
               </p>
             </li>
           ))}


### PR DESCRIPTION
## Summary
- make purchase amounts link to transaction details
- tighten types in MintCard by importing `ChangeEvent`
- clean up implicit `any` usage in profile and shell pages

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npx tsc --noEmit` *(fails to find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68578e42414c8320b357f61c8f7a86ea