### PR TITLE
Fix async params usage in shell page

### DIFF
--- a/src/app/shell/[id]/page.tsx
+++ b/src/app/shell/[id]/page.tsx
@@ -4,16 +4,17 @@ import type { NftAttribute } from '@/types/Nft'
 
 export const revalidate = 60
 
-export default async function ShellPage({ params }: { params: { id: string } }) {
+export default async function ShellPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
   const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY!
-  const url = `https://base-sepolia.g.alchemy.com/nft/v3/${apiKey}/getNFTMetadata?contractAddress=${MAIN_NFT_CONTRACT}&tokenId=${params.id}`
+  const url = `https://base-sepolia.g.alchemy.com/nft/v3/${apiKey}/getNFTMetadata?contractAddress=${MAIN_NFT_CONTRACT}&tokenId=${id}`
   const res = await fetch(url, { next: { revalidate: 60 } })
   if (!res.ok) notFound()
   const data = await res.json()
   const traits: NftAttribute[] = data?.metadata?.attributes ?? []
   return (
     <div style={{ maxWidth: 800, margin: '2rem auto' }}>
-      <h1>Shell #{params.id}</h1>
+      <h1>Shell #{id}</h1>
       <ul>
         {traits.map((t, i) => (
           <li key={i}>{t.trait_type}: {t.value}</li>


### PR DESCRIPTION
## Summary
- ensure dynamic route params are awaited in Shell page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579103104083209f96e9b5f8aeda9c