### PR TITLE
Fix null transaction warnings in MintCard

### DIFF
--- a/src/components/MintCard.tsx
+++ b/src/components/MintCard.tsx
@@ -52,12 +52,20 @@ export default function MintCard() {
 
       const provider = new JsonRpcProvider(`https://base-sepolia.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`)
       const receipt = await provider.waitForTransaction(hash)
+      if (!receipt) {
+        throw new Error('Transaction receipt not found')
+      }
+
       const iface = new Interface(CraftedCollectionABI.abi)
       const ids: string[] = []
       for (const log of receipt.logs) {
         try {
           const parsed = iface.parseLog(log)
-          if (parsed.name === 'Transfer' && parsed.args?.to?.toLowerCase() === address?.toLowerCase()) {
+          if (
+            parsed &&
+            parsed.name === 'Transfer' &&
+            parsed.args?.to?.toLowerCase() === address?.toLowerCase()
+          ) {
             ids.push(parsed.args.tokenId.toString())
           }
         } catch {}


### PR DESCRIPTION
## Summary
- guard against missing transaction receipts
- handle optional log parsing results

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a02b82bc832095acfad710165df1