### PR TITLE
Enhance minting UI and show minted count

### DIFF
--- a/src/app/sunnyside/stash/page.tsx
+++ b/src/app/sunnyside/stash/page.tsx
@@ -9,9 +9,11 @@ import Footer from '@/layout/Footers/LanderFooter'
 import s from '@/styles/Home.module.sass'
 import SignInWithEthereum from '@/components/SignInWithEthereum'
 import BuyNowButton from '@/components/BuyNowButton'
+import useTotalSupply from '@/hooks/useTotalSupply'
 
 export default function Home() {
   const isConnected = true
+  const totalSupply = useTotalSupply()
 
   return (
     <>
@@ -19,7 +21,9 @@ export default function Home() {
         <div className={s.dimmer}></div>
         <div className={s.links}>
           <ul className={s.features}>
-            <li className='textGreen pulse'>Limited Edition!</li>
+            <li className='textGreen pulse'>
+              {`Limited Edition${typeof totalSupply === 'number' ? ` – ${totalSupply}/888 minted` : '!'}`}
+            </li>
             <li>
               <h2>
                 FiendIng<i> </i>fathErs

--- a/src/components/MintCard.tsx
+++ b/src/components/MintCard.tsx
@@ -29,8 +29,13 @@ export default function MintCard() {
 
   const handleQuantityChange = (e: ChangeEvent<HTMLInputElement>) => {
     const val = Number(e.target.value)
-    setQuantity(val > maxAllowed ? maxAllowed : val)
+    if (Number.isNaN(val)) return
+    const clamped = Math.max(1, Math.min(maxAllowed, val))
+    setQuantity(clamped)
   }
+
+  const increase = () => setQuantity((q) => Math.min(maxAllowed, q + 1))
+  const decrease = () => setQuantity((q) => Math.max(1, q - 1))
 
   const handleMint = async (): Promise<void> => {
     if (!user) return
@@ -97,9 +102,34 @@ export default function MintCard() {
       <Image src='/assets/images/nft.jpg' alt='MFR NFT' width='300' height='300' />
       <p>Price: 0.03 ETH each</p>
 
-      <div>
-        <label>Quantity: </label>
-        <input type='number' min='1' max={maxAllowed} value={quantity} onChange={handleQuantityChange} />
+      <div className='flex items-center gap-2 mb-4'>
+        <label className='mr-2'>Quantity:</label>
+        <div className='flex'>
+          <button
+            type='button'
+            onClick={decrease}
+            disabled={quantity <= 1}
+            className='px-3 py-1 bg-gray-700 border border-gray-600 rounded-l disabled:opacity-50'
+          >
+            -
+          </button>
+          <input
+            type='number'
+            min='1'
+            max={maxAllowed}
+            value={quantity}
+            onChange={handleQuantityChange}
+            className='w-12 text-center bg-gray-700 border-t border-b border-gray-600'
+          />
+          <button
+            type='button'
+            onClick={increase}
+            disabled={quantity >= maxAllowed}
+            className='px-3 py-1 bg-gray-700 border border-gray-600 rounded-r disabled:opacity-50'
+          >
+            +
+          </button>
+        </div>
       </div>
 
       <button disabled={isPending || maxAllowed === 0} onClick={handleMint}>

--- a/src/hooks/useTotalSupply.ts
+++ b/src/hooks/useTotalSupply.ts
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { JsonRpcProvider, Contract } from 'ethers'
+import CraftedCollectionABI from '@/abi/CraftedCollection.json'
+import { MAIN_NFT_CONTRACT } from '@/lib/contracts'
+
+export default function useTotalSupply() {
+  const [supply, setSupply] = useState<number | null>(null)
+
+  useEffect(() => {
+    const fetchSupply = async () => {
+      try {
+        const provider = new JsonRpcProvider(
+          `https://base-sepolia.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`
+        )
+        const contract = new Contract(
+          MAIN_NFT_CONTRACT,
+          CraftedCollectionABI.abi,
+          provider
+        )
+        const result = await contract.totalSupply()
+        setSupply(Number(result))
+      } catch (err) {
+        console.error('Failed to fetch total supply', err)
+      }
+    }
+
+    fetchSupply()
+  }, [])
+
+  return supply
+}


### PR DESCRIPTION
## Summary
- add a hook to read `totalSupply` from the NFT contract
- add increment/decrement buttons next to mint quantity
- show how many NFTs have been minted on the stash page

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' etc.)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685838a4b1888320a30757a3217b61e8