### PR TITLE
Fix server component hook usage

### DIFF
--- a/src/app/sunnyside/stash/page.tsx
+++ b/src/app/sunnyside/stash/page.tsx
@@ -9,11 +9,10 @@ import Footer from '@/layout/Footers/LanderFooter'
 import s from '@/styles/Home.module.sass'
 import SignInWithEthereum from '@/components/SignInWithEthereum'
 import BuyNowButton from '@/components/BuyNowButton'
-import useTotalSupply from '@/hooks/useTotalSupply'
+import LimitedEditionLabel from '@/components/LimitedEditionLabel'
 
 export default function Home() {
   const isConnected = true
-  const totalSupply = useTotalSupply()
 
   return (
     <>
@@ -22,7 +21,7 @@ export default function Home() {
         <div className={s.links}>
           <ul className={s.features}>
             <li className='textGreen pulse'>
-              {`Limited Edition${typeof totalSupply === 'number' ? ` – ${totalSupply}/888 minted` : '!'}`}
+              <LimitedEditionLabel />
             </li>
             <li>
               <h2>

--- a/src/components/LimitedEditionLabel.tsx
+++ b/src/components/LimitedEditionLabel.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import useTotalSupply from '@/hooks/useTotalSupply'
+
+export default function LimitedEditionLabel() {
+  const totalSupply = useTotalSupply()
+  const suffix = typeof totalSupply === 'number' ? ` – ${totalSupply}/888 minted` : '!' 
+  return <>{`Limited Edition${suffix}`}</>
+}


### PR DESCRIPTION
## Summary
- add `LimitedEditionLabel` to handle minted count on the client
- reference `LimitedEditionLabel` from stash page instead of calling a hook directly

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583d92d9788320a7729fc4c37b9fd6