### PR TITLE
Fix mint modal gating and total price

### DIFF
--- a/src/components/MintCard.tsx
+++ b/src/components/MintCard.tsx
@@ -141,7 +141,7 @@ export default function MintCard() {
       <div className='label'>
         Current Price (<CountdownTimer targetDate='2025-06-23T23:59:00Z' />)
       </div>
-      <p className='priceBox'>0.03</p>
+      <p className='priceBox'>{(Number(totalPrice) / 1e18).toFixed(2)}</p>
 
       <div className='gap-2 mb-4'>
         <label className='block hidden'>How Many?</label>

--- a/src/components/MintModal.tsx
+++ b/src/components/MintModal.tsx
@@ -1,15 +1,22 @@
 'use client'
 
 import MintCard from './MintCard'
+import useAuthUser from '@/hooks/useAuthUser'
 
 export default function MintModal({ onClose }: { onClose: () => void }) {
+  const { user, isConnected } = useAuthUser()
+
   return (
     <div className='mintModal'>
       <div className='mintModalWrapper'>
         <button onClick={onClose} className='absolute top-2 right-2 text-white' aria-label='Close'>
           ✕
         </button>
-        <MintCard />
+        {user && isConnected ? (
+          <MintCard />
+        ) : (
+          <p className='p-4 text-center'>Please connect and sign in to mint.</p>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- gate the mint modal behind wallet connection and sign in
- show total price based on selected quantity

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585e6fb33c832097e5163b74722374