### PR TITLE
Add referral input status classes

### DIFF
--- a/src/components/MintCard.tsx
+++ b/src/components/MintCard.tsx
@@ -31,6 +31,15 @@ export default function MintCard() {
   const [referral, setReferral] = useState('')
   const [refStatus, setRefStatus] = useState<'loading' | 'found' | 'not_found' | null>(null)
 
+  const referralClass =
+    refStatus === 'loading'
+      ? 'checking'
+      : refStatus === 'found'
+      ? 'success'
+      : refStatus === 'not_found'
+      ? 'error'
+      : ''
+
   const sanitizeUsername = (value: string) => {
     let v = value.replace(/[-\s]+/g, '_').toLowerCase()
     v = v.replace(/[^a-z0-9_]/g, '')
@@ -176,7 +185,13 @@ export default function MintCard() {
         <hr />
         <div className='tagBox'>
           <label className='block hidden'>Tag a Connect?</label>
-          <input className='w-full mb-0' type='text' value={referral} onChange={(e) => handleReferralChange(e.target.value)} placeholder='Tag Your Connect' />
+          <input
+            className={`w-full mb-0 ${referralClass}`}
+            type='text'
+            value={referral}
+            onChange={(e) => handleReferralChange(e.target.value)}
+            placeholder='Tag Your Connect'
+          />
         </div>
         <div className='errorMessage'>
           {error && <p>Error: {error.message}</p>}

--- a/src/styles/globals.sass
+++ b/src/styles/globals.sass
@@ -565,6 +565,15 @@ input, textarea
   &.changed
     border-color: var(--color-mfr-yellow)
     outline: 2px solid var(--color-mfr-yellow)
+  &.checking
+    border-color: var(--color-mfr-yellow)
+    animation: pulser 1s infinite alternate
+  &.success
+    border-color: var(--green-alt)
+    outline: 2px solid var(--green-alt)
+  &.error
+    border-color: var(--red)
+    outline: 2px solid var(--red)
   &::-webkit-calendar-picker-indicator
     filter: invert(1)
 


### PR DESCRIPTION
## Summary
- mark referral field with checking/success/error classes based on status
- style those new classes in global styles

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a3a60b1c83208788b539da3235bb