### PR TITLE
Add breadcrumb notifications

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Web3Providers } from '@/layout/Providers/Web3Providers'
 import { MintModalProvider } from '@/layout/Providers/MintModalProvider'
 import ClientAppShell from '@/systems/runtime/ClientAppShell'
 import BodyClassManager from '@/systems/runtime/BodyClassManager'
+import { BreadcrumbProvider } from '@/layout/Providers/BreadcrumbProvider'
 
 import '@/styles/globals.sass'
 import '@coinbase/onchainkit/styles.css'
@@ -45,12 +46,14 @@ export default function RootLayout({
         <Web3Providers>
           <AuthProvider>
             <MintModalProvider>
-              {/* -- runtime mgr -- */}
-              <ClientAppShell>
-                <Header />
-                <main>{children}</main>
-                <Footer />
-              </ClientAppShell>
+              <BreadcrumbProvider>
+                {/* -- runtime mgr -- */}
+                <ClientAppShell>
+                  <Header />
+                  <main>{children}</main>
+                  <Footer />
+                </ClientAppShell>
+              </BreadcrumbProvider>
             </MintModalProvider>
           </AuthProvider>
         </Web3Providers>

--- a/src/hooks/useActivityBreadcrumbs.ts
+++ b/src/hooks/useActivityBreadcrumbs.ts
@@ -1,0 +1,41 @@
+'use client'
+
+import { useRef, useEffect } from 'react'
+import { useActivityLog } from '@/hooks/useActivityLog'
+import useAuthUser from '@/hooks/useAuthUser'
+import { useBreadcrumbs } from '@/layout/Providers/BreadcrumbProvider'
+
+export function useActivityBreadcrumbs() {
+  const { user } = useAuthUser()
+  const log = useActivityLog(user?.uid ?? '')
+  const { addBreadcrumb } = useBreadcrumbs()
+
+  const initialized = useRef(false)
+  const lastSeen = useRef(0)
+
+  useEffect(() => {
+    if (log.length === 0) return
+
+    if (!initialized.current) {
+      const latest = log[0].createdAt?.getTime?.() ?? Date.now()
+      lastSeen.current = latest
+      initialized.current = true
+      return
+    }
+
+    const newEntries = log.filter((entry) => {
+      const t = entry.createdAt?.getTime?.()
+      return typeof t === 'number' && t > lastSeen.current
+    })
+
+    if (newEntries.length > 0) {
+      lastSeen.current = Math.max(
+        ...newEntries.map((e) => e.createdAt!.getTime())
+      )
+      newEntries
+        .slice()
+        .reverse()
+        .forEach((e) => addBreadcrumb(e.label))
+    }
+  }, [log, addBreadcrumb])
+}

--- a/src/hooks/useGlobalPurchaseNotifications.ts
+++ b/src/hooks/useGlobalPurchaseNotifications.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { collectionGroup, onSnapshot, orderBy, query } from 'firebase/firestore'
+import { useEffect, useRef } from 'react'
+import { db } from '@/lib/firebaseClient'
+import { useBreadcrumbs } from '@/layout/Providers/BreadcrumbProvider'
+
+function getTime(val: any): number {
+  if (!val) return 0
+  if (val instanceof Date) return val.getTime()
+  if (typeof val === 'number') return val
+  if (val.toDate) return val.toDate().getTime()
+  return 0
+}
+
+export function useGlobalPurchaseNotifications() {
+  const { addBreadcrumb } = useBreadcrumbs()
+  const initialized = useRef(false)
+  const lastSeen = useRef(0)
+
+  useEffect(() => {
+    const q = query(collectionGroup(db, 'purchases'), orderBy('createdAt', 'desc'))
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        const docs = snap.docs.map((d) => ({ id: d.id, ...d.data() }))
+        if (!initialized.current) {
+          if (docs.length > 0) lastSeen.current = getTime(docs[0].createdAt)
+          initialized.current = true
+          return
+        }
+
+        docs.forEach((doc) => {
+          const ts = getTime((doc as any).createdAt)
+          if (ts > lastSeen.current) {
+            lastSeen.current = ts
+            const quantity = (doc as any).quantity ?? 1
+            addBreadcrumb(
+              `Someone purchased x${quantity} Shell${quantity > 1 ? 's' : ''}!`
+            )
+          }
+        })
+      },
+      (err) => {
+        console.error('[Purchases] Snapshot error:', err)
+      }
+    )
+
+    return () => unsub()
+  }, [addBreadcrumb])
+}

--- a/src/hooks/useRuntime.ts
+++ b/src/hooks/useRuntime.ts
@@ -2,6 +2,8 @@
 
 // hooks/useRuntime.ts
 import { useLocationTracker } from '@/hooks/useLocationTracker'
+import { useActivityBreadcrumbs } from '@/hooks/useActivityBreadcrumbs'
+import { useGlobalPurchaseNotifications } from '@/hooks/useGlobalPurchaseNotifications'
 //import { useXPRewardManager } from '@/hooks/useXPRewardManager'
 //import { useQuestSystem } from '@/hooks/useQuestSystem'
 //import { useAnalyticsTracker } from '@/hooks/useAnalyticsTracker'
@@ -9,6 +11,8 @@ import { useLocationTracker } from '@/hooks/useLocationTracker'
 // Registry array of runtime managers (each is a hook function)
 const RuntimeManagers = [
   useLocationTracker,
+  useActivityBreadcrumbs,
+  useGlobalPurchaseNotifications,
   //useXPRewardManager,
   //useQuestSystem,
   //useAnalyticsTracker,

--- a/src/layout/Providers/BreadcrumbProvider.tsx
+++ b/src/layout/Providers/BreadcrumbProvider.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+interface Breadcrumb {
+  id: number
+  message: string
+}
+
+interface BreadcrumbContext {
+  addBreadcrumb: (message: string) => void
+}
+
+const BreadcrumbContext = createContext<BreadcrumbContext>({
+  addBreadcrumb: () => {},
+})
+
+export function BreadcrumbProvider({ children }: { children: ReactNode }) {
+  const [crumbs, setCrumbs] = useState<Breadcrumb[]>([])
+
+  const addBreadcrumb = (message: string) => {
+    setCrumbs((prev) => [...prev, { id: Date.now() + Math.random(), message }])
+  }
+
+  useEffect(() => {
+    if (crumbs.length === 0) return
+    const timers = crumbs.map((c) =>
+      setTimeout(
+        () =>
+          setCrumbs((curr) => curr.filter((crumb) => crumb.id !== c.id)),
+        5000
+      )
+    )
+    return () => {
+      timers.forEach((t) => clearTimeout(t))
+    }
+  }, [crumbs])
+
+  return (
+    <BreadcrumbContext.Provider value={{ addBreadcrumb }}>
+      {children}
+      <div className='breadcrumb-container pointer-events-none'>
+        {crumbs.map((c) => (
+          <div key={c.id} className='breadcrumb'>
+            {c.message}
+          </div>
+        ))}
+      </div>
+    </BreadcrumbContext.Provider>
+  )
+}
+
+export function useBreadcrumbs() {
+  return useContext(BreadcrumbContext)
+}

--- a/src/styles/globals.sass
+++ b/src/styles/globals.sass
@@ -986,3 +986,9 @@ body
       @apply bg-gray-800 text-[var(--green)] px-4 py-2 rounded-md text-[15px] font-medium
       border: 1px solid var(--dark)
       border-bottom-width: 3px
+
+.breadcrumb-container
+  @apply fixed top-4 left-4 z-[1000] flex flex-col gap-2
+
+.breadcrumb
+  @apply bg-gray-800 text-[var(--green)] px-3 py-1 rounded-md shadow pointer-events-auto text-sm


### PR DESCRIPTION
## Summary
- add breadcrumb provider to display temporary messages
- show user activity log entries in breadcrumbs
- show global purchase events in breadcrumbs via collectionGroup query
- integrate breadcrumb provider into root layout
- register breadcrumb hooks in runtime
- style breadcrumb notifications

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ccddcfb48320b18bb7d656bfd9ec