### PR TITLE
Improve toast fade and stacking

### DIFF
--- a/src/layout/Providers/ToastProvider.tsx
+++ b/src/layout/Providers/ToastProvider.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { createContext, useContext, useState, ReactNode } from 'react'
 
 interface Toast {
   id: number
   message: string
+  closing?: boolean
 }
 
 interface ToastContext {
@@ -19,29 +20,28 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([])
 
   const addToast = (message: string) => {
-    setToasts((prev) => [...prev, { id: Date.now() + Math.random(), message }])
-  }
+    const id = Date.now() + Math.random()
+    setToasts((prev) => [...prev, { id, message }])
 
-  useEffect(() => {
-    if (toasts.length === 0) return
-    const timers = toasts.map((c) =>
-      setTimeout(
-        () =>
-          setToasts((curr) => curr.filter((toast) => toast.id !== c.id)),
-        5000
+    setTimeout(() => {
+      setToasts((curr) =>
+        curr.map((toast) =>
+          toast.id === id ? { ...toast, closing: true } : toast
+        )
       )
-    )
-    return () => {
-      timers.forEach((t) => clearTimeout(t))
-    }
-  }, [toasts])
+    }, 6000)
+
+    setTimeout(() => {
+      setToasts((curr) => curr.filter((toast) => toast.id !== id))
+    }, 6500)
+  }
 
   return (
     <ToastContext.Provider value={{ addToast }}>
       {children}
       <div className='toast-container pointer-events-none'>
         {toasts.map((c) => (
-          <div key={c.id} className='toast'>
+          <div key={c.id} className={`toast${c.closing ? ' closing' : ''}`}>
             {c.message}
           </div>
         ))}

--- a/src/styles/globals.sass
+++ b/src/styles/globals.sass
@@ -997,3 +997,13 @@ body
   border: 1px solid var(--green)
   border-bottom-width: 3px
   transform-origin: 0 0
+  max-height: 200px
+  transition: opacity 0.5s, margin 0.5s, padding 0.5s, max-height 0.5s
+
+.toast.closing
+  opacity: 0
+  margin-top: 0 !important
+  margin-bottom: 0 !important
+  padding-top: 0 !important
+  padding-bottom: 0 !important
+  max-height: 0


### PR DESCRIPTION
## Summary
- add smooth toast fading and closing behavior
- style toast transitions for fading and collapsing

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ffc1e694832096289bff5f82e68c