### PR TITLE
Fix timestamp getTime issue

### DIFF
--- a/src/hooks/useActivityToasts.ts
+++ b/src/hooks/useActivityToasts.ts
@@ -1,41 +1,42 @@
-'use client'
+"use client";
 
-import { useRef, useEffect } from 'react'
-import { useActivityLog } from '@/hooks/useActivityLog'
-import useAuthUser from '@/hooks/useAuthUser'
-import { useToasts } from '@/layout/Providers/ToastProvider'
+import { useRef, useEffect } from "react";
+import { useActivityLog } from "@/hooks/useActivityLog";
+import useAuthUser from "@/hooks/useAuthUser";
+import { useToasts } from "@/layout/Providers/ToastProvider";
+import { getTime } from "@/utils/getTime";
 
 export function useActivityToasts() {
-  const { user } = useAuthUser()
-  const log = useActivityLog(user?.uid ?? '')
-  const { addToast } = useToasts()
+  const { user } = useAuthUser();
+  const log = useActivityLog(user?.uid ?? "");
+  const { addToast } = useToasts();
 
-  const initialized = useRef(false)
-  const lastSeen = useRef(0)
+  const initialized = useRef(false);
+  const lastSeen = useRef(0);
 
   useEffect(() => {
-    if (log.length === 0) return
+    if (log.length === 0) return;
 
     if (!initialized.current) {
-      const latest = log[0].createdAt?.getTime?.() ?? Date.now()
-      lastSeen.current = latest
-      initialized.current = true
-      return
+      const latest = getTime(log[0].createdAt) || Date.now();
+      lastSeen.current = latest;
+      initialized.current = true;
+      return;
     }
 
     const newEntries = log.filter((entry) => {
-      const t = entry.createdAt?.getTime?.()
-      return typeof t === 'number' && t > lastSeen.current
-    })
+      const t = getTime(entry.createdAt);
+      return t > lastSeen.current;
+    });
 
     if (newEntries.length > 0) {
       lastSeen.current = Math.max(
-        ...newEntries.map((e) => e.createdAt!.getTime())
-      )
+        ...newEntries.map((e) => getTime(e.createdAt)),
+      );
       newEntries
         .slice()
         .reverse()
-        .forEach((e) => addToast(e.label))
+        .forEach((e) => addToast(e.label));
     }
-  }, [log, addToast])
+  }, [log, addToast]);
 }

--- a/src/hooks/useGlobalPurchaseNotifications.ts
+++ b/src/hooks/useGlobalPurchaseNotifications.ts
@@ -1,66 +1,62 @@
-'use client'
+"use client";
 
-import { collectionGroup, onSnapshot, orderBy, query } from 'firebase/firestore'
-import { useEffect, useRef } from 'react'
-import { db } from '@/lib/firebaseClient'
-import { useToasts } from '@/layout/Providers/ToastProvider'
-
-interface TimestampLike {
-  toDate: () => Date
-}
+import {
+  collectionGroup,
+  onSnapshot,
+  orderBy,
+  query,
+} from "firebase/firestore";
+import { useEffect, useRef } from "react";
+import { db } from "@/lib/firebaseClient";
+import { useToasts } from "@/layout/Providers/ToastProvider";
+import type { TimestampLike } from "@/utils/getTime";
+import { getTime } from "@/utils/getTime";
 
 interface PurchaseDoc {
-  id: string
-  createdAt?: Date | number | TimestampLike
-  quantity?: number
-  [key: string]: unknown
-}
-
-function getTime(val: Date | number | TimestampLike | null | undefined): number {
-  if (!val) return 0
-  if (val instanceof Date) return val.getTime()
-  if (typeof val === 'number') return val
-  if (typeof (val as TimestampLike).toDate === 'function') return (
-    val as TimestampLike
-  ).toDate().getTime()
-  return 0
+  id: string;
+  createdAt?: Date | number | TimestampLike;
+  quantity?: number;
+  [key: string]: unknown;
 }
 
 export function useGlobalPurchaseNotifications() {
-  const { addToast } = useToasts()
-  const initialized = useRef(false)
-  const lastSeen = useRef(0)
+  const { addToast } = useToasts();
+  const initialized = useRef(false);
+  const lastSeen = useRef(0);
 
   useEffect(() => {
-    const q = query(collectionGroup(db, 'purchases'), orderBy('createdAt', 'desc'))
+    const q = query(
+      collectionGroup(db, "purchases"),
+      orderBy("createdAt", "desc"),
+    );
     const unsub = onSnapshot(
       q,
       (snap) => {
         const docs = snap.docs.map(
-          (d) => ({ id: d.id, ...d.data() }) as PurchaseDoc
-        )
+          (d) => ({ id: d.id, ...d.data() }) as PurchaseDoc,
+        );
         if (!initialized.current) {
-          if (docs.length > 0) lastSeen.current = getTime(docs[0].createdAt)
-          initialized.current = true
-          return
+          if (docs.length > 0) lastSeen.current = getTime(docs[0].createdAt);
+          initialized.current = true;
+          return;
         }
 
         docs.forEach((doc) => {
-          const ts = getTime(doc.createdAt)
+          const ts = getTime(doc.createdAt);
           if (ts > lastSeen.current) {
-            lastSeen.current = ts
-            const quantity = doc.quantity ?? 1
+            lastSeen.current = ts;
+            const quantity = doc.quantity ?? 1;
             addToast(
-              `Someone purchased x${quantity} Shell${quantity > 1 ? 's' : ''}!`
-            )
+              `Someone purchased x${quantity} Shell${quantity > 1 ? "s" : ""}!`,
+            );
           }
-        })
+        });
       },
       (err) => {
-        console.error('[Purchases] Snapshot error:', err)
-      }
-    )
+        console.error("[Purchases] Snapshot error:", err);
+      },
+    );
 
-    return () => unsub()
-  }, [addToast])
+    return () => unsub();
+  }, [addToast]);
 }

--- a/src/utils/getTime.ts
+++ b/src/utils/getTime.ts
@@ -1,0 +1,15 @@
+export interface TimestampLike {
+  toDate: () => Date;
+}
+
+export function getTime(
+  val: Date | number | TimestampLike | null | undefined,
+): number {
+  if (!val) return 0;
+  if (val instanceof Date) return val.getTime();
+  if (typeof val === "number") return val;
+  if (typeof (val as TimestampLike).toDate === "function") {
+    return (val as TimestampLike).toDate().getTime();
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `getTime` util to handle `Date` and Firestore timestamps
- unify timestamp conversions in activity and purchase toasts

## Testing
- `npx prettier -w src/hooks/useActivityToasts.ts src/hooks/useGlobalPurchaseNotifications.ts src/utils/getTime.ts`
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68599d72c62c8320b41af3cb0242be5b