### PR TITLE
Fix telegram login search params

### DIFF
--- a/src/app/telegram/login/page.tsx
+++ b/src/app/telegram/login/page.tsx
@@ -1,19 +1,19 @@
 'use client'
 
-import { useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 import { getAuth } from 'firebase/auth'
 import AuthGate from '@/components/gates/AuthGate'
 
 export default function TelegramLoginPage() {
-  const params = useSearchParams()
-  const chatId = params.get('chatId') || ''
-  const username = params.get('username') || ''
   const [status, setStatus] = useState('Linking Telegram...')
 
   const linkTelegram = async () => {
     try {
       const token = await getAuth().currentUser!.getIdToken()
+      const params = new URLSearchParams(window.location.search)
+      const chatId = params.get('chatId') || ''
+      const username = params.get('username') || ''
+
       await fetch('/api/telegram/link', {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Summary
- fix Telegram login page by parsing query params from `window.location`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599ef7b7788320b45c664da8883a31