### PR TITLE
Fix Tailwind PostCSS plugin

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,8 @@
 const config = {
-  plugins: ['@tailwindcss/postcss'],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }
 
 export default config

--- a/src/styles/Container.module.sass
+++ b/src/styles/Container.module.sass
@@ -12,7 +12,7 @@
   transform: translate(-50%,-50%)
 
 .egg
-  @apply inline-block ms-2 me-2 rounded-full
+  @apply inline-block ml-2 mr-2 rounded-full
   width: 2rem
   height: 2rem
   background-color: var(--color-mfr-glow)


### PR DESCRIPTION
## Summary
- fix PostCSS configuration so Tailwind utilities are generated
- use traditional margin-left/right utilities in Container styles

## Testing
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6859a0d09ba08320bcb81b8218085bf1