### PR TITLE
Fix Tailwind v4 setup

### DIFF
--- a/images.d.ts
+++ b/images.d.ts
@@ -1,0 +1,24 @@
+declare module '*.png' {
+  const value: import('next/dist/shared/lib/get-img-props').StaticImageData;
+  export default value;
+}
+
+declare module '*.jpg' {
+  const value: import('next/dist/shared/lib/get-img-props').StaticImageData;
+  export default value;
+}
+
+declare module '*.jpeg' {
+  const value: import('next/dist/shared/lib/get-img-props').StaticImageData;
+  export default value;
+}
+
+declare module '*.gif' {
+  const value: import('next/dist/shared/lib/get-img-props').StaticImageData;
+  export default value;
+}
+
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,6 @@
 const config = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Summary
- add declarations for importing image assets
- include `next-env.d.ts` for TypeScript and Next.js
- update `postcss.config.mjs` to use the new Tailwind v4 plugin

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build` *(fails: Cannot fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6859a42f65748320b714d8f02a6fe25e