### PR TITLE
Store referral tagbacks per purchase

### DIFF
--- a/src/app/settings/role/page.tsx
+++ b/src/app/settings/role/page.tsx
@@ -119,6 +119,16 @@ export default function RoleSettingsPage() {
     }
   }
 
+  const handleTweet = () => {
+    if (!username) return
+    const origin = process.env.NEXT_PUBLIC_APP_URL || window.location.origin
+    const url = `${origin}/assets/images/rathed.svg`
+    const text = `I just set my role as ${ratType} on Made for Rats!`
+    const shareUrl =
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&via=${username}`
+    window.open(shareUrl, '_blank')
+  }
+
   const hasChanges = ratType !== originalRatType || secondaryRatType !== originalSecondaryRatType
 
   if (loading)
@@ -179,6 +189,7 @@ export default function RoleSettingsPage() {
           <button onClick={handleSave} disabled={loading || !hasChanges} className={`button ${!hasChanges ? 'disabled' : ''}`}>
             Save
           </button>
+          <button type='button' onClick={handleTweet} className='button'>Tweet Role</button>
         </div>
 
         {message && <p className='formnote'>{message}</p>}

--- a/src/components/MintCard.tsx
+++ b/src/components/MintCard.tsx
@@ -24,7 +24,7 @@ export default function MintCard() {
   const totalPrice: bigint = pricePerNFT * BigInt(quantity)
 
   const { writeContractAsync, isPending, error } = useWriteContract()
-  const { user, userData, address } = useAuthUser()
+  const { user, address } = useAuthUser()
   const addXP = useAddExperience(user)
   const { count } = useNftCount()
   const maxAllowed = Math.max(0, 3 - count)
@@ -114,6 +114,7 @@ export default function MintCard() {
         txHash: hash,
         createdAt: serverTimestamp(),
         purchaseId,
+        tagback: referral && refStatus === 'found' ? referral : null,
       })
 
       const userRef = doc(db, 'users', user.uid)
@@ -122,9 +123,6 @@ export default function MintCard() {
         totalSpent: increment(Number(totalPrice) / 1e18),
       })
 
-      if (referral && refStatus === 'found' && !(userData && userData.tagback)) {
-        await updateDoc(userRef, { tagback: referral })
-      }
 
       await logActivity({
         uid: user.uid,

--- a/src/layout/Providers/AuthProvider.tsx
+++ b/src/layout/Providers/AuthProvider.tsx
@@ -93,7 +93,6 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
             experience: 0,
             level: 1,
             createdAt: Date.now(),
-            tagback: null,
           })
         }
       }

--- a/src/types/Purchase.ts
+++ b/src/types/Purchase.ts
@@ -8,5 +8,6 @@ export interface Purchase {
   quantity: number
   nftIds: string[]
   txHash: string
+  tagback?: string | null
   createdAt?: import('firebase/firestore').Timestamp | Date
 }

--- a/src/types/UserData.ts
+++ b/src/types/UserData.ts
@@ -9,6 +9,5 @@ export interface UserData {
   lastLogin?: number
   locations?: string[]
   username?: string
-  tagback?: string | null
   // add additional fields for user profile here
 }


### PR DESCRIPTION
## Summary
- relocate referral info to each purchase record
- clean usertag settings header
- improve Tweet Role button to fill in usertag and image

## Testing
- `npm install`
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859eb7624f08320be1d6d6ed58c6f79