### PR TITLE
Improve env handling and session security

### DIFF
--- a/src/app/api/siwe/session/route.ts
+++ b/src/app/api/siwe/session/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: NextRequest) {
       secure: process.env.NODE_ENV === 'production',
       path: '/',
       maxAge: 60 * 60 * 24 * 5, // 5 days
-      sameSite: 'lax',
+      sameSite: 'strict',
     })
 
     return new NextResponse(JSON.stringify({ success: true }), {

--- a/src/app/api/siwe/verify/route.ts
+++ b/src/app/api/siwe/verify/route.ts
@@ -3,18 +3,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { SiweMessage } from 'siwe'
 import admin from 'firebase-admin'
+import { env } from '@/lib/env'
 
 // init admin once
 if (!admin.apps.length) {
   admin.initializeApp({
     credential: admin.credential.cert({
-      projectId: process.env.FIREBASE_PROJECT_ID!,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL!,
-      privateKey: (() => {
-        const key = process.env.FIREBASE_PRIVATE_KEY!
-        const normalized = key.replace(/\\n/g, '\n')
-        return normalized.includes('BEGIN') ? normalized : Buffer.from(normalized, 'base64').toString('utf8')
-      })(),
+      projectId: env.firebase.projectId,
+      clientEmail: env.firebase.clientEmail,
+      privateKey: env.firebase.privateKey,
     }),
   })
 }

--- a/src/app/api/telegram/link/route.ts
+++ b/src/app/api/telegram/link/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth, dbAdmin } from '@/lib/firebaseAdmin'
+import { env } from '@/lib/env'
 
-const TELEGRAM_API = `https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}`
-const GROUP_ID = process.env.TELEGRAM_GROUP_ID
+const TELEGRAM_API = `https://api.telegram.org/bot${env.telegram.botToken}`
+const GROUP_ID = env.telegram.groupId
 
 async function updateNickname(chatId: string, usertag: string, level: number) {
   if (!GROUP_ID) return

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,23 @@
+export function assertEnv(name: string, value: string | undefined): string {
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`)
+  }
+  return value
+}
+
+function normalizeKey(value: string): string {
+  const replaced = value.replace(/\\n/g, '\n')
+  return replaced.includes('BEGIN') ? replaced : Buffer.from(replaced, 'base64').toString('utf8')
+}
+
+export const env = {
+  firebase: {
+    projectId: assertEnv('FIREBASE_PROJECT_ID', process.env.FIREBASE_PROJECT_ID),
+    clientEmail: assertEnv('FIREBASE_CLIENT_EMAIL', process.env.FIREBASE_CLIENT_EMAIL),
+    privateKey: normalizeKey(assertEnv('FIREBASE_PRIVATE_KEY', process.env.FIREBASE_PRIVATE_KEY)),
+  },
+  telegram: {
+    botToken: assertEnv('TELEGRAM_BOT_TOKEN', process.env.TELEGRAM_BOT_TOKEN),
+    groupId: process.env.TELEGRAM_GROUP_ID,
+  },
+}

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -2,24 +2,14 @@
 import { initializeApp, cert, getApps } from 'firebase-admin/app'
 import { getAuth } from 'firebase-admin/auth'
 import { getFirestore } from 'firebase-admin/firestore'
-
-function assertEnv(name: string, value: string | undefined): string {
-  if (!value) {
-    throw new Error(`Missing required Firebase env var: ${name}`)
-  }
-  return value
-}
+import { env } from './env'
 
 if (!getApps().length) {
   initializeApp({
     credential: cert({
-      projectId: assertEnv('FIREBASE_PROJECT_ID', process.env.FIREBASE_PROJECT_ID),
-      clientEmail: assertEnv('FIREBASE_CLIENT_EMAIL', process.env.FIREBASE_CLIENT_EMAIL),
-      privateKey: (() => {
-        const key = assertEnv('FIREBASE_PRIVATE_KEY', process.env.FIREBASE_PRIVATE_KEY)
-        const normalized = key //.replace(/\\n/g, '\n')
-        return normalized.includes('BEGIN') ? normalized : Buffer.from(normalized, 'base64').toString('utf8')
-      })(),
+      projectId: env.firebase.projectId,
+      clientEmail: env.firebase.clientEmail,
+      privateKey: env.firebase.privateKey,
     }),
   })
 }


### PR DESCRIPTION
## Summary
- centralize sensitive environment variables in a new `env.ts`
- refactor Firebase admin and API routes to use centralized env access
- tighten session cookie with `SameSite=strict`

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685a2ed1f434832093d976fe17d1bbef