### PR TITLE
Setup theme font variables

### DIFF
--- a/src/styles/Docs.module.sass
+++ b/src/styles/Docs.module.sass
@@ -34,7 +34,7 @@
       user-select: none
       a
         @apply block text-[18px] text-[#fff] flex items-center gap-[6px] 
-        //font-family: "SKT"
+        //font-family: var(--font-skt)
         line-height: 1
         //letter-spacing: .03em
         text-decoration: none!important
@@ -88,7 +88,7 @@
     filter: brightness(120%)
     box-shadow: 0 2px 4px rgba(0,0,0,.4)
     letter-spacing: -0.03em
-    font-family: "Instant Karma"
+    font-family: var(--font-bleedcry)
     line-height: 12px
     b
       @apply inline-block pr-[2px] pt-[4px]
@@ -101,7 +101,7 @@
 .indexList
   @apply flex flex-wrap items-center w-full text-[28px] text-[#fff] pt-[40px]
   padding-left: 0!important
-  font-family: "SKT"
+  font-family: var(--font-skt)
   letter-spacing: 0.03em
   & > *
     @apply flex-1 flex flex-col items-center
@@ -128,7 +128,7 @@
   @apply w-full flex items-start justify-between max-w-[690px] pt-[40px] pb-[60px] min-h-[340px]
   a
     @apply flex flex-col items-center justify-center text-[#fff] text-[28px]
-    font-family: "SKT"
+    font-family: var(--font-skt)
     text-decoration: none!important
     letter-spacing: 0.05em
     svg
@@ -203,19 +203,19 @@ ul
 .navFolder
   @apply flex cursor-pointer text-[#fff] gap-[4px]
   //letter-spacing: .05em
-  //font-family: "SKT"
+  //font-family: var(--font-skt)
   .navTitle
     @apply text-[18px] capitalize text-[#fff]
     &:hover, &:active
       color: var(--color-mfr-yellow)
     //font-weight: bold
-    //font-family: "Instant Karma"
+    //font-family: var(--font-bleedcry)
     //letter-spacing: .05em
   .toggleIcon
     @apply text-[var(--color-mfr-glow)] text-[20px]
     
     line-height: 20px
-    font-family: "Instant Karma"
+    font-family: var(--font-bleedcry)
 
 
 @variant lg

--- a/src/styles/Footer.module.sass
+++ b/src/styles/Footer.module.sass
@@ -9,10 +9,10 @@
   @apply absolute left-[50vw] top-[5vw] md:top-[15vw] w-[40vw] text-center z-[10]
   h4
     @apply text-[6vw] text-[#fff]
-    font-family: "SKT"
+    font-family: var(--font-skt)
   p
     @apply text-[3vw]
-    font-family: "Instant Karma"
+    font-family: var(--font-bleedcry)
     line-height: 1.1
 
 .links

--- a/src/styles/Header.module.sass
+++ b/src/styles/Header.module.sass
@@ -24,7 +24,7 @@
   span
     &.tagline
       @apply flex-1 text-3xl md:text-5xl text-[#fff] fixed bottom-[20px] left-[10px] md:left-[20px]
-      font-family: "Instant Karma", sans-serif
+      font-family: var(--font-bleedcry), sans-serif
       font-weight: normal
       text-shadow: 0 3px 0 var(--color-dark)
       span
@@ -97,7 +97,7 @@
   @apply fixed bottom-[0] rotate-[180deg] left-[0] z-[9999998] w-full h-[40px] bg-[var(--color-mfr-glow)] text-[var(--color-dark)] text-[22px] hidden
   background: url(../../public/assets/images/edge.svg) no-repeat 50% 50%
   background-size: 100% 100%
-  font-family: "SKT"
+  font-family: var(--font-skt)
   a
     @apply absolute top-[10px] left-[33%] text-[var(--color-dark)]
     line-height: 16px
@@ -117,7 +117,7 @@
   transform: rotateX(16deg) rotateY(-24deg)
   transform-style: preserve-3d
   box-shadow: 3px 3px 0px #349e31, 6px 6px 4px rgba(0,0,0,.12)
-  font-family: "DM Mono"
+  font-family: var(--font-dm-mono)
   user-select: none
 
   .statNum

--- a/src/styles/Home.module.sass
+++ b/src/styles/Home.module.sass
@@ -23,7 +23,7 @@
     transform: translateY(-50%)
     a, button.buyNow
       @apply relative w-[200px] md:w-[45vw] lg:w-[35vw] transition transition-transform text-center text-[#fff] text-[60px] md:text-[11vw]
-      font-family: "SKT"
+      font-family: var(--font-skt)
       line-height: 1.1
       text-decoration: none!important
       letter-spacing: 0.03em
@@ -120,7 +120,7 @@
   @apply w-full max-w-[90vw] md:max-w-[52vw] mx-auto absolute left-[5vw] md:left-[40vw] top-[20vw] z-[99] text-[4.5vw]
   line-height: .9
   //transform: translateX(-50%)
-  font-family: "Instant Karma"
+  font-family: var(--font-bleedcry)
   p
     text-shadow: 0 4px 0 var(--color-dark), 0 2px 16px rgba(0,0,0,1), 0 2px 8px rgba(0,0,0,1)
   hr
@@ -129,7 +129,7 @@
     @apply text-[6vw]
     b
       @apply inline-block ml-[-0.12em] pr-[0.06em] relative
-      font-family: "Instant Karma"
+      font-family: var(--font-bleedcry)
     span
       @apply text-[var(--color-mfr-glow)]
   p, h2
@@ -176,7 +176,7 @@
 .feature
   @apply absolute text-[#fff] text-[4vw] z-[10]
   line-height: 1
-  font-family: "SKT"
+  font-family: var(--font-skt)
   letter-spacing: 0.03em
   text-shadow: 0 4px 0 var(--color-dark)
   text-decoration: none!important
@@ -192,7 +192,7 @@
   .caption
     @apply text-[.4em] absolute top-[50%] left-[50%] text-center text-[var(--color-mfr-glow)] px-[.26em] py-[.8em] rotate-[-5deg] mt-[-.2em]
     //background-color: rgba(0,0,0,.5)
-    font-family: "Instant Karma"
+    font-family: var(--font-bleedcry)
     transform: translate(-50%, -50%)
     letter-spacing: -0.03em
     text-shadow: 0 2px 0 var(--color-dark), -2px 2px 0 var(--color-dark), 2px 2px 0 var(--color-dark), 0 -2px 0 var(--color-dark), 0 3px 5px rgba(0,0,0,1)
@@ -255,7 +255,7 @@
   box-shadow: 0 .13em .26em rgba(0,0,0,.4),  0 .13em 0 #32932f
   transition: background-color 0.3s, color 0.3s
   letter-spacing: -0.03em
-  font-family: "Instant Karma"
+  font-family: var(--font-bleedcry)
   white-space: nowrap
   span
     @apply h-[.8em] inline-block pt-[.13em]
@@ -301,7 +301,7 @@
 
 .biglink
   @apply relative mb-12 py-[18px] px-[24px] transition-all flex items-center text-[var(--color-dark)] text-[60px] bg-[var(--green-alt)] rounded-lg
-  font-family: "SKT"
+  font-family: var(--font-skt)
   //text-shadow: 0 4px 0px var(--color-dark)
   letter-spacing: 0.02em
   transition: color .3s transform .3s
@@ -342,7 +342,7 @@
   @apply block relative flex flex-col items-center justify-center text-center pb-12 pt-24 z-[5]
   background: url(../../public/assets/images/rathead-glow-red.svg) no-repeat 60vw 10vw
   background-size: 35vw auto
-  font-family: "Instant Karma"
+  font-family: var(--font-bleedcry)
   h2
     @apply rotate-[-2deg] text-[12vw] md:text-[8vw] pb-[2vw]
     line-height: 1
@@ -365,7 +365,7 @@
     @apply max-w-[90vw] md:max-w-[45vw] text-[var(--color-mfr-glow)] text-[6vw] lg:text-[3vw]
     line-height: 1
     letter-spacing: 0.02em
-    font-family: "Instant Karma"
+    font-family: var(--font-bleedcry)
 
 .steps
   @apply relative flex flex-col max-w-[1200px] mx-auto w-full pt-16 z-[5]
@@ -375,7 +375,7 @@
     @apply flex flex-col items-center pb-12
     h3
       @apply text-[12vw] lg:text-[64px] text-[#fff]
-      font-family: "SKT"
+      font-family: var(--font-skt)
     p
       @apply text-[2vw] text-[var(--color-mfr-glow)] text-center
       line-height: 2vw
@@ -436,7 +436,7 @@
     text-shadow: none
     line-height: 1
     font-weight: bold
-    //font-family: "Instant Karma"
+    //font-family: var(--font-bleedcry)
     white-space: nowrap
     box-shadow: 0 1px 0 var(--color-dark)
     &.tight
@@ -444,7 +444,7 @@
       font-weight: 500
       line-height: 1
       line-height: 1
-      font-family: "DM Sans"
+      font-family: var(--font-dm-sans)
       box-shadow: none
       span
         @apply h-[2vw]
@@ -469,7 +469,7 @@
     h3
       @apply text-[20px] md:text-[2vw] mb-0
       letter-spacing: 0.03em
-      font-family: "SKT"
+      font-family: var(--font-skt)
       font-weight: normal
       text-shadow: 0 2px 0 var(--color-dark)
     &.listTitle

--- a/src/styles/Profile.module.sass
+++ b/src/styles/Profile.module.sass
@@ -26,7 +26,7 @@
     @apply text-[var(--color-dark)]
   h3
     @apply text-[24px] mb-[5px]
-    font-family: "DM Sans"
+    font-family: var(--font-dm-sans)
     font-weight: bold
     letter-spacing: -0.03em
     &:first-letter

--- a/src/styles/ProfileCard.module.sass
+++ b/src/styles/ProfileCard.module.sass
@@ -19,7 +19,7 @@
     font-weight: bold
   .nickname
     @apply block italic text-[24px] text-[var(--color-mfr-glow)] ml-[-4px]
-    font-family: "Instant Karma"
+    font-family: var(--font-bleedcry)
   .stats
     @apply basis-[100%] w-full mx-1 my-[0] rounded-sm text-[16px]
     li 

--- a/src/styles/globals.sass
+++ b/src/styles/globals.sass
@@ -2,14 +2,14 @@
 @use "./theme"
 
 @font-face
-  font-family: 'SKT'
+  font-family: var(--font-skt)
   src: url('/assets/fonts/SKTANDDESTROY.woff2') format('woff2'), url('/assets/fonts/SKTANDDESTROY.woff') format('woff')
   font-weight: normal
   font-style: normal
 
 @font-face
-  font-family: 'Instant Karma'
-  src: url('/assets/fonts/bleedcry.woff2') format('woff2'), url('/assets/fonts/bleedcry.woff') format('woff')
+  font-family: 'Bleedcry'
+  src: url('/assets/fonts/Bleedcry.woff2') format('woff2'), url('/assets/fonts/Bleedcry.woff') format('woff')
   font-weight: normal
   font-style: normal
 
@@ -73,7 +73,7 @@ body
   @apply pt-[140px]
   background: var(--background)
   color: var(--foreground)
-  font-family: "DM Sans", sans-serif
+  font-family: var(--font-dm-sans), sans-serif
   font-size: 20px
   line-height: 28px
   overflow-x: hidden
@@ -121,7 +121,7 @@ code, .carbboard
   line-height: 22px
   background: url(../../public/assets/images/cardboard-pattern.jpg) 0 0
   background-size: 100% auto
-  font-family: "DM Mono"  
+  font-family: var(--font-dm-mono)  
 
 p code
   @apply py-[0] px-[2px] mx-[2px] mb-[0]
@@ -132,7 +132,7 @@ blockquote
   font-weight: bold
   background: url(../../public/assets/images/block-middle.jpg) 0 0
   background-size: auto 100%
-  font-family: "DM Mono"
+  font-family: var(--font-dm-mono)
   a
     @apply text-[var(--green-alt)]
   &:before
@@ -180,7 +180,7 @@ hr
       background-size: 100% auto
 
 h1,h2
-  font-family: "SKT"
+  font-family: var(--font-skt)
   margin-bottom: 20px
   color: #fff
   letter-spacing: 0.02em
@@ -201,7 +201,7 @@ h1,h2
     transform: skew(10deg, 0)
 
 h3,h4,h5
-  font-family: "Instant Karma"
+  font-family: var(--font-bleedcry)
   margin-bottom: 10px
   color: var(--color-mfr-glow)
   letter-spacing: 0.02em
@@ -225,7 +225,7 @@ section
   @apply fixed flex overflow-hidden items-center justify-center w-full h-[0] bottom-[0] left-0 z-[993] text-[8vw] lg:text-[54px] text-[var(--color-dark)]
   a
     @apply px-8 py-3 flex flex items-center justify-center text-center text-[var(--color-dark)]
-    font-family: "SKT"
+    font-family: var(--font-skt)
     letter-spacing: 0.01em
     text-decoration: none!important
     img
@@ -420,7 +420,7 @@ button
 
   
 h2.ock-font-family
-  font-family: "SKT"
+  font-family: var(--font-skt)
   font-weight: normal
   font-size: 24px
 
@@ -485,7 +485,7 @@ h2.ock-font-family
 
 .ock-connect
   @apply bg-transparent relative transition-all duration-300 w-[140px] h-[140px] min-w-[140px] p-0 text-[24px] bottom-[-7px] right-[-20px] z-[2]
-  font-family: "SKT"
+  font-family: var(--font-skt)
   letter-spacing: 0.07em
   line-height: 1.1
   color: transparent
@@ -554,7 +554,7 @@ form
     & > span
       @apply text-[24px] text-[#fff]
       letter-spacing: .03em
-      font-family: "Instant Karma"
+      font-family: var(--font-bleedcry)
 
 // style inputs, selects, textareas
 input, textarea
@@ -629,7 +629,7 @@ select::placeholder
 
 footer.upside
   @apply fixed top-[0] left-0 w-full z-[99997] pt-[34px] pl-[30px] pr-[95px] flex items-start justify-between
-  font-family: "Instant Karma"
+  font-family: var(--font-bleedcry)
   .navMenu
     @apply flex items-center justify-end
     a, button
@@ -701,12 +701,12 @@ footer.upside
 .svgTitle
   @apply text-[9px] uppercase text-[#fff]
   letter-spacing: .1em
-  font-family: "DM Sans"
+  font-family: var(--font-dm-sans)
   font-weight: bold
 
 .svgText
   @apply text-[24px]
-  font-family: "Instant Karma"
+  font-family: var(--font-bleedcry)
 
 #mfrAmountDecimal
   @apply inline-block text-[50%] pl-[4px]
@@ -720,7 +720,7 @@ footer.upside
 
 .preTitle
   @apply inline-block text-[1.8vw] tracking-wide mb-[2vw] rotate-[-4deg] ml-[-1vw] text-[var(--color-mfr-glow)]
-  font-family: "SKT"
+  font-family: var(--font-skt)
   text-shadow: 0 2px 0 var(--color-dark)
   letter-spacing: 0.06em
 
@@ -736,7 +736,7 @@ footer.upside
   text-shadow: 0 2px 0 var(--color-dark)!important
   animation: pulser 1s infinite alternate ease-in-out
   transform-origin: 0 100%
-  font-family: "Instant Karma"
+  font-family: var(--font-bleedcry)
   font-weight: normal
 
 @keyframes pulser
@@ -773,7 +773,7 @@ a.dd-link
 .button
   @apply text-[var(--color-dark)] min-w-[180px] text-[32px] py-[10px] px-[15px]
   background: transparent url(../../public/assets/images/sq-button-yellow.svg) no-repeat 50% 50% / 100% 100%
-  font-family: "SKT"
+  font-family: var(--font-skt)
   letter-spacing: 0.03em
   transition: scale .3s
   &:hover, &:active
@@ -806,7 +806,7 @@ form
     @apply absolute right-[5px] top-[-30px] flex items-center justify-between
     a
       @apply text-[16px]
-      font-family: "DM Sans"
+      font-family: var(--font-dm-sans)
       font-weight: medium
       letter-spacing: 0
       text-decoration: none
@@ -833,7 +833,7 @@ p.formnote
     @apply mb-0
   .xp
     @apply text-2xl
-    font-family: "Instant Karma"
+    font-family: var(--font-bleedcry)
     line-height: 1
 
 .xpPill
@@ -850,7 +850,7 @@ p.formnote
   @apply bg-[#1e2939] text-[var(--color-mfr-glow)] font-bold tracking-tighter p-4 rounded-md rotate-[-2deg] text-[18px]
   border: 1px solid var(--color-mfr-glow)
   border-bottom-width: 3px
-  font-family: "DM Sans"
+  font-family: var(--font-dm-sans)
   text-shadow: 0 0 6px rgba(52,211,153,0.8)
   
 
@@ -981,7 +981,7 @@ body
       border: 2px solid var(--dark)
       border-bottom-width: 4px
     p
-      font-family: "Instant Karma"
+      font-family: var(--font-bleedcry)
     button.closeButton
       @apply bg-gray-800 text-[var(--green)] px-4 py-2 rounded-md text-[15px] font-medium
       border: 1px solid var(--dark)

--- a/src/styles/theme.sass
+++ b/src/styles/theme.sass
@@ -6,3 +6,5 @@
   --color-mfr-green: #68c460
   --color-mfr-yellow: #ffff0f
   --color-mfr-purple: #6615f7
+  --font-skt: 'SKT'
+  --font-bleedcry: 'Bleedcry'


### PR DESCRIPTION
## Summary
- centralize font families in the theme
- reference fonts via CSS variables across styles
- rename Instant Karma font-face to Bleedcry

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a33ddf20483208b097bfa4592dbb0