### PR TITLE
Fix useSearchParams error by adding Suspense

### DIFF
--- a/src/app/telegram/login/page.tsx
+++ b/src/app/telegram/login/page.tsx
@@ -1,11 +1,19 @@
 'use client'
 
 import { useSearchParams } from 'next/navigation'
-import { useState } from 'react'
+import { Suspense, useState } from 'react'
 import { getAuth } from 'firebase/auth'
 import AuthGate from '@/components/gates/AuthGate'
 
 export default function TelegramLoginPage() {
+  return (
+    <Suspense>
+      <TelegramLoginClient />
+    </Suspense>
+  )
+}
+
+function TelegramLoginClient() {
   const params = useSearchParams()
   const chatId = params.get('chatId') || ''
   const username = params.get('username') || ''


### PR DESCRIPTION
## Summary
- wrap `useSearchParams` usage on Telegram login page in a Suspense boundary

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685a3b697b748320ac962bc88e279a49