### PR TITLE
Update telegram login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ npm run dev
 
 ## Telegram Bot
 
-A bot can listen for the `/login` command and send users to `/telegram/login`. Provide `TELEGRAM_BOT_TOKEN` in your environment and optionally `TELEGRAM_GROUP_ID` to update titles in a group.
+A bot can listen for the `/login` command and send users to `/telegram/login`. Provide `TELEGRAM_BOT_TOKEN` in your environment and optionally `TELEGRAM_GROUP_ID` to update titles in a group. When a user links their Telegram account the bot now sends them a confirmation message and, if they already have a username on the site, updates their display name in the configured group.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- send Telegram confirmation when linking account
- set group display name to username
- document new Telegram flow in README

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4cfa87c883209faa211fd8f7403a