### PR TITLE
Add Telegram logout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ npm run dev
 
 ## Telegram Bot
 
-A bot can listen for the `/login` command and send users to `/telegram/login`. Provide `TELEGRAM_BOT_TOKEN` in your environment and optionally `TELEGRAM_GROUP_ID` to update titles in a group. When a user links their Telegram account the bot now sends them a confirmation message and, if they already have a username on the site, updates their display name in the configured group.
+A bot can listen for the `/login` command and send users to `/telegram/login`. Provide `TELEGRAM_BOT_TOKEN` in your environment and optionally `TELEGRAM_GROUP_ID` to update titles in a group. When a user links their Telegram account the bot now sends them a confirmation message and, if they already have a username on the site, updates their display name in the configured group. Running `/login` again will notify the user if their Telegram is already connected. The bot also supports `/logout` to disconnect the current chat from the site.
 
 ## Troubleshooting
 

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -10,6 +10,41 @@ if (!TOKEN) {
 const API = `https://api.telegram.org/bot${TOKEN}`
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || ''
 
+// Firebase Admin setup for tracking linked users
+const {
+  initializeApp,
+  cert,
+  getApps,
+} = require('firebase-admin/app')
+const { getFirestore, FieldValue } = require('firebase-admin/firestore')
+
+function normalizeKey(value) {
+  const replaced = value.replace(/\\n/g, '\n')
+  return replaced.includes('BEGIN')
+    ? replaced
+    : Buffer.from(replaced, 'base64').toString('utf8')
+}
+
+function assertEnv(name, value) {
+  if (!value) {
+    console.error(`Missing required env var: ${name}`)
+    process.exit(1)
+  }
+  return value
+}
+
+if (!getApps().length) {
+  initializeApp({
+    credential: cert({
+      projectId: assertEnv('FIREBASE_PROJECT_ID', process.env.FIREBASE_PROJECT_ID),
+      clientEmail: assertEnv('FIREBASE_CLIENT_EMAIL', process.env.FIREBASE_CLIENT_EMAIL),
+      privateKey: normalizeKey(assertEnv('FIREBASE_PRIVATE_KEY', process.env.FIREBASE_PRIVATE_KEY)),
+    }),
+  })
+}
+
+const db = getFirestore()
+
 async function sendMessage(chatId, text) {
   await fetch(`${API}/sendMessage`, {
     method: 'POST',
@@ -18,13 +53,37 @@ async function sendMessage(chatId, text) {
   })
 }
 
+async function findUserByChatId(chatId) {
+  const snap = await db.collection('users').where('telegramChatId', '==', String(chatId)).limit(1).get()
+  return snap.empty ? null : { id: snap.docs[0].id, ...snap.docs[0].data() }
+}
+
 async function handleUpdate(update) {
   const msg = update.message
   if (!msg || !msg.text) return
   const text = msg.text.trim()
+
   if (text === '/login') {
+    const existing = await findUserByChatId(msg.from.id)
+    if (existing) {
+      await sendMessage(msg.chat.id, 'Your Telegram is already connected to the site.')
+      return
+    }
     const link = `${APP_URL}/telegram/login?chatId=${msg.from.id}&username=${encodeURIComponent(msg.from.username || '')}`
     await sendMessage(msg.chat.id, `Open this link to connect your account:\n${link}`)
+  }
+
+  if (text === '/logout') {
+    const existing = await findUserByChatId(msg.from.id)
+    if (!existing) {
+      await sendMessage(msg.chat.id, 'No linked account found.')
+      return
+    }
+    await db
+      .collection('users')
+      .doc(existing.id)
+      .update({ telegramChatId: FieldValue.delete(), telegramUsername: FieldValue.delete() })
+    await sendMessage(msg.chat.id, 'Your Telegram account has been disconnected.')
   }
 }
 


### PR DESCRIPTION
## Summary
- improve Telegram bot login logic
- add logout command handling
- mention logout in documentation

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next' or its corresponding type declarations)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4f7247448320b30bde2487f584ce