### PR TITLE
Refactor telegram bot to ESM

### DIFF
--- a/telegram-bot.mjs
+++ b/telegram-bot.mjs
@@ -1,5 +1,5 @@
 // Simple Telegram bot using long polling
-// Run with: node telegram-bot.js
+// Run with: node telegram-bot.mjs
 
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN
 if (!TOKEN) {
@@ -11,12 +11,12 @@ const API = `https://api.telegram.org/bot${TOKEN}`
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || ''
 
 // Firebase Admin setup for tracking linked users
-const {
+import {
   initializeApp,
   cert,
   getApps,
-} = require('firebase-admin/app')
-const { getFirestore, FieldValue } = require('firebase-admin/firestore')
+} from 'firebase-admin/app'
+import { getFirestore, FieldValue } from 'firebase-admin/firestore'
 
 function normalizeKey(value) {
   const replaced = value.replace(/\\n/g, '\n')


### PR DESCRIPTION
## Summary
- rename telegram-bot.js to telegram-bot.mjs and switch to ES module imports

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5109a4608320a97a44b0efe1a405