### PR TITLE
Improve Telegram login link

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ npm run dev
 
 A bot can listen for the `/login` command and send users to `/telegram/login`. Provide `TELEGRAM_BOT_TOKEN` in your environment and optionally `TELEGRAM_GROUP_ID` to update titles in a group. When a user links their Telegram account the bot now sends them a confirmation message and, if they already have a username on the site, updates their display name in the configured group. Running `/login` again will notify the user if their Telegram is already connected. The bot also supports `/logout` to disconnect the current chat from the site.
 
+The bot uses `NEXT_PUBLIC_APP_URL` to build the login link. Set this variable to the full base URL of your site (for example `https://localhost:3000`) so that the bot sends a complete link rather than a relative path.
+
 ## Troubleshooting
 
 If you encounter `FirebaseError: Missing or insufficient permissions`, check your Firestore Security Rules. For local development you can allow authenticated users to read and write by using:

--- a/telegram-bot.mjs
+++ b/telegram-bot.mjs
@@ -8,7 +8,9 @@ if (!TOKEN) {
 }
 
 const API = `https://api.telegram.org/bot${TOKEN}`
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || ''
+// Use a sensible default when NEXT_PUBLIC_APP_URL is not provided so the
+// login link works during local development.
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://localhost:3000'
 
 // Firebase Admin setup for tracking linked users
 import { initializeApp, cert, getApps } from 'firebase-admin/app'


### PR DESCRIPTION
## Summary
- default `APP_URL` to `https://localhost:3000` when missing
- mention `NEXT_PUBLIC_APP_URL` in Telegram bot section of README

## Testing
- `npm install`
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a5ae400d08320a6435398fc95f152