### PR TITLE
Add inline login button for Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ npm run dev
 
 A bot can listen for the `/login` command and send users to `/telegram/login`. Provide `TELEGRAM_BOT_TOKEN` in your environment and optionally `TELEGRAM_GROUP_ID` to update titles in a group. When a user links their Telegram account the bot now sends them a confirmation message and, if they already have a username on the site, updates their display name in the configured group. Running `/login` again will notify the user if their Telegram is already connected. The bot also supports `/logout` to disconnect the current chat from the site.
 
+The `/login` reply includes an inline button that opens the login link. Telegram does not allow bots to launch external URLs automatically, so users must tap the button or the link provided in the message.
+
 The bot uses `NEXT_PUBLIC_APP_URL` to build the login link. Set this variable to the full base URL of your site (for example `https://localhost:3000`) so that the bot sends a complete link rather than a relative path.
 
 ## Troubleshooting

--- a/telegram-bot.mjs
+++ b/telegram-bot.mjs
@@ -41,11 +41,11 @@ if (!getApps().length) {
 
 const db = getFirestore()
 
-async function sendMessage(chatId, text) {
+async function sendMessage(chatId, text, extra = {}) {
   await fetch(`${API}/sendMessage`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ chat_id: chatId, text }),
+    body: JSON.stringify({ chat_id: chatId, text, ...extra }),
   })
 }
 
@@ -66,7 +66,15 @@ async function handleUpdate(update) {
       return
     }
     const link = `${APP_URL}/telegram/login?chatId=${msg.from.id}&username=${encodeURIComponent(msg.from.username || '')}`
-    await sendMessage(msg.chat.id, `Open this link to connect your account:\n${link}`)
+    await sendMessage(
+      msg.chat.id,
+      `Open this link to connect your account:\n${link}`,
+      {
+        reply_markup: {
+          inline_keyboard: [[{ text: 'Connect account', url: link }]],
+        },
+      },
+    )
   }
 
   if (text === '/logout') {


### PR DESCRIPTION
## Summary
- show login link with inline button when using `/login`
- document new behavior in the Telegram bot section of the README

## Testing
- `npx tsc --noEmit` *(fails: cannot find module declarations)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6090012c8320aed1a2cb254c2e22