### PR TITLE
Fix purchase notifications trigger only after login

### DIFF
--- a/src/hooks/useGlobalPurchaseNotifications.ts
+++ b/src/hooks/useGlobalPurchaseNotifications.ts
@@ -9,6 +9,7 @@ import {
 import { useEffect, useRef } from "react";
 import { db } from "@/lib/firebaseClient";
 import { useToasts } from "@/layout/Providers/ToastProvider";
+import useAuthUser from "@/hooks/useAuthUser";
 import type { TimestampLike } from "@/utils/getTime";
 import { getTime } from "@/utils/getTime";
 
@@ -21,10 +22,12 @@ interface PurchaseDoc {
 
 export function useGlobalPurchaseNotifications() {
   const { addToast } = useToasts();
+  const { user } = useAuthUser();
   const initialized = useRef(false);
   const lastSeen = useRef(0);
 
   useEffect(() => {
+    if (!user) return;
     const q = query(
       collectionGroup(db, "purchases"),
       orderBy("createdAt", "desc"),
@@ -58,5 +61,5 @@ export function useGlobalPurchaseNotifications() {
     );
 
     return () => unsub();
-  }, [addToast]);
+  }, [addToast, user]);
 }


### PR DESCRIPTION
## Summary
- check for authenticated user before subscribing to purchase notifications

## Testing
- `npm install`
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685aac8fdde88320898603bcc2146b9c