### PR TITLE
Fix usertag deletion & improve invalid feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ service cloud.firestore {
                     request.auth.uid == request.resource.data.uid &&
                     request.resource.data.username == username &&
                     username.size() >= 5;
+      allow delete: if request.auth != null &&
+                    request.auth.uid == resource.data.uid;
     }
 
     // User documents and their subcollections

--- a/src/app/settings/usertag/page.tsx
+++ b/src/app/settings/usertag/page.tsx
@@ -234,7 +234,9 @@ export default function UsertagSettingsPage() {
                 : usernameStatus === 'unavailable'
                 ? 'Username unavailable'
                 : !usernameStatus && !usernameValid && newUsername !== currentUsername
-                ? 'Invalid username'
+                ? newUsername.length < 6
+                  ? 'Username must be at least 6 characters'
+                  : 'Invalid username'
                 : ''
             return msg ? <p className='labelNotify'>{msg}</p> : null
           })()}


### PR DESCRIPTION
## Summary
- remove old usertag via Firestore rules
- show specific message when usertag is too short

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b4a856ca08320a1f2e8a85d9a2afb